### PR TITLE
优化知识库查询以及工具定义方法

### DIFF
--- a/src/agents/tools_factory.py
+++ b/src/agents/tools_factory.py
@@ -66,7 +66,7 @@ def regist_tool(
 
 
 class KnowledgeRetrieverModel(BaseModel):
-    query: str = Field(description="查询的关键词，查询的时候，应该尽量以关键词的形式进行查询，不要使用复杂的句子。\n.")
+    query: str = Field(description="查询的关键词，查询的时候，应该尽量以可能帮助回答这个问题的关键词进行查询，不要直接使用用户的原始输入去查询。")
 
 
 

--- a/src/agents/tools_factory.py
+++ b/src/agents/tools_factory.py
@@ -66,19 +66,25 @@ def regist_tool(
 
 
 class KnowledgeRetrieverModel(BaseModel):
-    query: str = Field(description="The query to get knowledge graph.")
+    query: str = Field(description="查询的关键词，查询的时候，应该尽量以关键词的形式进行查询，不要使用复杂的句子。\n.")
 
 
 
 def get_all_tools():
     """获取所有工具"""
     tools = _TOOLS_REGISTRY.copy()
+
+    # 获取所有知识库
     for db_Id, retrieve_info in knowledge_base.get_retrievers().items():
         name = f"retrieve_{retrieve_info['name']}"
+        description = (
+            f"使用 {retrieve_info['name']} 知识库进行检索。\n"
+            f"下面是这个知识库的描述：\n{retrieve_info['description']}"
+        )
         tools[name] = StructuredTool.from_function(
             retrieve_info["retriever"],
             name=name,
-            description=retrieve_info["description"],
+            description=description,
             args_schema=KnowledgeRetrieverModel)
 
     return tools

--- a/src/core/operators.py
+++ b/src/core/operators.py
@@ -1,0 +1,48 @@
+"""
+这里面存放是 RAG 相关的一些组件
+"""
+
+from src.utils import prompts
+
+class BaseOperator:
+    """
+    基类
+    """
+    template = None
+
+    def __init__(self):
+        pass
+
+    def call(self, **kwargs):
+        pass
+
+    def __call__(self, **kwargs):
+        """
+        所有 RAG 相关组件的调用接口
+        """
+        return self.call(**kwargs)
+
+
+
+class HyDEOperator(BaseOperator):
+    """
+    HyDE 重写查询
+    """
+    template = prompts.HYDE_PROMPT_TEMPLATE
+
+    def __init__(self):
+        super().__init__()
+
+    @classmethod
+    def call(cls, model_callable, query, context_str, **kwargs):
+        """
+        重写查询
+
+        Args:
+            model_callable: 模型调用函数
+            query: 查询
+            context_str: 上下文
+        """
+        prompt = cls.template.format(query=query, context_str=context_str)
+        response = model_callable(prompt)
+        return response

--- a/src/core/retriever.py
+++ b/src/core/retriever.py
@@ -2,6 +2,8 @@ from src import config, knowledge_base, graph_base
 from src.models.rerank_model import get_reranker
 from src.utils.logging_config import logger
 from src.models import select_model
+from src.core.operators import HyDEOperator
+
 
 class Retriever:
 
@@ -151,8 +153,8 @@ class Retriever:
             rewritten_query = model.predict(rewritten_query_prompt).content
 
         if rewrite_query_span == "hyde":
-            hy_doc = model.predict(rewritten_query).content
-            rewritten_query = f"{rewritten_query} {hy_doc}"
+            res = HyDEOperator.call(model_callable=model.predict, query=query, context_str=history_query)
+            rewritten_query = res.content
 
         return rewritten_query
 

--- a/src/utils/prompts.py
+++ b/src/utils/prompts.py
@@ -57,3 +57,15 @@ keywords_prompt_template = """
 不要改变关键词的语言
 <文本>{text}</文本>
 """
+
+HYDE_PROMPT_TEMPLATE = (
+    "Please write a passage to answer the question\n"
+    "Try to include as many key details as possible.\n"
+    "\n"
+    "\n"
+    "{context_str}\n"
+    "\n"
+    "{query}\n"
+    "\n"
+    'Passage:\n'
+)

--- a/web/src/views/AgentView.vue
+++ b/web/src/views/AgentView.vue
@@ -165,7 +165,7 @@
 
           <!-- 添加工具选择部分 -->
           <a-form-item label="可用工具" name="tools" class="config-item">
-            <p class="description">选择要启用的工具</p>
+            <p class="description">选择要启用的工具（注：retrieve 工具仅展现了与当前向量模型匹配的知识库，详情请查看 docker 日志。）</p>
             <a-form-item-rest>
               <div class="tools-switches">
                 <div v-for="tool in availableTools" :key="tool" class="tool-switch-item">

--- a/web/src/views/DataBaseView.vue
+++ b/web/src/views/DataBaseView.vue
@@ -5,18 +5,19 @@
       description="知识型数据库，主要是非结构化的文本组成，使用向量检索使用。如果出现问题，可以检查 saves/data/database.json 查看配置。"
     >
       <template #actions>
-        <a-button type="primary" @click="newDatabase.open=true">新建数据库</a-button>
+        <a-button type="primary" @click="newDatabase.open=true">新建知识库</a-button>
       </template>
     </HeaderComponent>
 
-    <a-modal :open="newDatabase.open" title="新建数据库" @ok="createDatabase" @cancel="newDatabase.open=false">
-      <h3>数据库名称<span style="color: var(--error-color)">*</span></h3>
-      <a-input v-model:value="newDatabase.name" placeholder="新建数据库名称" />
-      <h3 style="margin-top: 20px;">数据库描述</h3>
+    <a-modal :open="newDatabase.open" title="新建知识库" @ok="createDatabase" @cancel="newDatabase.open=false">
+      <h3>知识库名称<span style="color: var(--error-color)">*</span></h3>
+      <a-input v-model:value="newDatabase.name" placeholder="新建知识库名称" />
+      <h3 style="margin-top: 20px;">知识库描述</h3>
+      <p style="color: var(--gray-700); font-size: 14px;">在智能体流程中，这里的描述会作为工具的描述。智能体会根据知识库的标题和描述来选择合适的工具。所以这里描述的越详细，智能体越容易选择到合适的工具。</p>
       <a-textarea
         v-model:value="newDatabase.description"
-        placeholder="新建数据库描述"
-        :auto-size="{ minRows: 2, maxRows: 5 }"
+        placeholder="新建知识库描述"
+        :auto-size="{ minRows: 5, maxRows: 10 }"
       />
       <!-- <h3 style="margin-top: 20px;">向量维度</h3>
       <p>必须与向量模型 {{ configStore.config.embed_model }} 一致</p>
@@ -31,7 +32,7 @@
         <div class="top">
           <div class="icon"><PlusOutlined /></div>
           <div class="info">
-            <h3>新建数据库</h3>
+            <h3>新建知识库</h3>
           </div>
         </div>
         <p>导入您自己的文本数据或通过Webhook实时写入数据以增强 LLM 的上下文。</p>


### PR DESCRIPTION
在 RAG 的流程中，初始化了 Operator 这个概念，后续会将更多的 RAG 组件定义为 Operator，这样逻辑更加清晰，也没有引入更加复杂的结构操作。

比如这个简单的 HyDEOperator

```python
class HyDEOperator(BaseOperator):
    """
    HyDE 重写查询
    """
    template = prompts.HYDE_PROMPT_TEMPLATE

    def __init__(self):
        super().__init__()

    @classmethod
    def call(cls, model_callable, query, context_str, **kwargs):
        """
        重写查询

        Args:
            model_callable: 模型调用函数
            query: 查询
            context_str: 上下文
        """
        prompt = cls.template.format(query=query, context_str=context_str)
        response = model_callable(prompt)
        return response

```

优化了工具定义的方法，让大模型能够更好的查找并使用这些工具，目前还需要优化的点在于大模型还没有很好的对 Query 重写，这部分可能需要在检索模块里面去完成。

失败案例，这个在配备了重写查询操作的标准的 RAG 流程中是没问题的

![image](https://github.com/user-attachments/assets/04992db1-ba66-4989-b234-748cbc5339db)
