### PR TITLE
添加对于 think 标签的解析

### DIFF
--- a/web/src/components/MessageComponent.vue
+++ b/web/src/components/MessageComponent.vue
@@ -15,7 +15,7 @@
             <caret-right-outlined :rotate="isActive ? 90 : 0" />
           </template>
           <a-collapse-panel key="show" :header="message.status=='reasoning' ? '正在思考...' : '推理过程'" class="reasoning-header">
-            <p class="reasoning-content">{{ message.reasoning_content }}</p>
+            <p class="reasoning-content">{{ message.reasoning_content.trim() }}</p>
           </a-collapse-panel>
         </a-collapse>
       </div>
@@ -56,7 +56,7 @@
       <!-- 工具调用 (AgentView特有) -->
       <slot v-else-if="message.toolCalls && Object.keys(message.toolCalls).length > 0" name="tool-calls"></slot>
 
-      <div v-else class="err-msg" @click="$emit('retry')">
+      <div v-else-if="!isProcessing" class="err-msg" @click="$emit('retry')">
         请求错误，请重试。{{ message.message }}
       </div>
 


### PR DESCRIPTION
对于没有将思考过程转成 reasoning_content 的消息，在前端解析 think tag，同时也不影响有正常的 think 的内容输出：
![image](https://github.com/user-attachments/assets/c2a5b13b-256a-4d62-9dd4-01586ceda65d)

![image](https://github.com/user-attachments/assets/844d2dc4-6e77-47a9-8fa6-d42378df11d7)
