### PR TITLE
fix: 补充LangChain 的 TextLoader 隐式引用的chardet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "tomli-w",
     "aiofiles>=24.1.0",
     "aiohttp>=3.9.0",
+    "chardet>=5.0.0",
     "deepagents>=0.2.5",
     "json-repair>=0.54.0",
     "openpyxl>=3.1.5",


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**
01-06 17:16:13 INFO client.py:203: 成功下载 '凡人修仙传-上-UTF-8_1767690940314.txt' 从存储桶 'ref-kb-d003313e3157b41b8a20b3d3d1a7be77' 
01-06 17:16:13 DEBUG indexing.py:485: File downloaded to temp path: /tmp/tmpx4uh14w8.txt 
01-06 17:16:13 DEBUG indexing.py:650: Cleaned up temp file: /tmp/tmpx4uh14w8.txt 
01-06 17:16:13 ERROR base.py:253: Failed to parse file file_04ee51: No module named 'chardet' 
01-06 17:16:13 DEBUG base.py:946: Saved milvus metadata 
01-06 17:16:13 DEBUG base.py:620: Removed file file_04ee51 from processing queue 
01-06 17:16:13 ERROR knowledge_router.py:410: Parse failed for file_04ee51: No module named 'chardet'

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范