### PR TITLE
fix(script): powershell脚本在拼接TAVILY_API_KEY时需要换行

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -41,7 +41,7 @@ SILICONFLOW_API_KEY=$apiKey
 "@
 
     if (-not [string]::IsNullOrEmpty($TAVILY_API_KEY)) {
-        $envContent += "TAVILY_API_KEY=$TAVILY_API_KEY"
+        $envContent += "`nTAVILY_API_KEY=$TAVILY_API_KEY"
     }
 
     $envContent | Out-File -FilePath ".env" -Encoding UTF8


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**
修复前：
<img width="868" height="180" alt="image" src="https://github.com/user-attachments/assets/95e07169-5a24-495c-a2b6-14d4b6385575" />
修复后：

<img width="782" height="260" alt="image" src="https://github.com/user-attachments/assets/6e3863af-cc7a-4c1b-b3e9-03abc66d5102" />

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范