### PR TITLE
Fix None handling in knowledge tool filter

### DIFF
--- a/src/agents/common/tools.py
+++ b/src/agents/common/tools.py
@@ -133,7 +133,10 @@ def get_kb_based_tools(db_names: list[str] | None = None) -> list:
     # 获取所有知识库
     kb_tools = []
     retrievers = knowledge_base.get_retrievers()
-    db_ids = [kb_id for kb_id, kb in retrievers.items() if kb["name"] in db_names] or None
+    if db_names is None:
+        db_ids = None
+    else:
+        db_ids = [kb_id for kb_id, kb in retrievers.items() if kb["name"] in db_names]
 
     def _create_retriever_wrapper(db_id: str, retriever_info: dict[str, Any]):
         """创建检索器包装函数的工厂函数，避免闭包变量捕获问题"""


### PR DESCRIPTION
## 背景
`get_kb_based_tools` 支持 `db_names=None`，表示不做过滤并返回全部工具。

## 问题
当 `db_names` 为 `None` 时仍执行 `kb['name'] in db_names`，会触发 `TypeError: argument of type 'NoneType' is not iterable`，导致工具初始化失败。

## 修复
- `db_names is None` 时直接设置 `db_ids=None`
- 仅在 `db_names` 有值时才执行过滤

## 影响
修复默认路径崩溃，传入具体 `db_names` 的行为不变。

## 变更
- `src/agents/common/tools.py`
