### PR TITLE
fix: fix multiple Human in the loop approvals getting stuck

### DIFF
--- a/server/routers/chat_router.py
+++ b/server/routers/chat_router.py
@@ -819,11 +819,17 @@ async def resume_agent_chat(
                         content=getattr(msg, "content", ""), msg=msg_dict, metadata=metadata, status="loading"
                     )
 
+                # 检查是否有新的 interrupt（支持多次 human in the loop）
+                langgraph_config = {"configurable": input_context}
+                async for chunk in check_and_handle_interrupts(
+                    agent, langgraph_config, make_resume_chunk, meta, thread_id
+                ):
+                    yield chunk
+
                 meta["time_cost"] = asyncio.get_event_loop().time() - start_time
                 yield make_resume_chunk(status="finished", meta=meta)
 
                 # 保存消息到数据库
-                langgraph_config = {"configurable": input_context}
                 conv_manager = ConversationManager(db)
                 await save_messages_from_langgraph_state(
                     agent_instance=agent,


### PR DESCRIPTION
## Description
Fix issue #453: When multiple Human in the loop tool calls occur in a single conversation, the second call gets stuck.

## Change Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Other

## Root Cause
- The main chat flow (`stream_agent_chat`) checks for pending interrupts after streaming ends by calling `check_and_handle_interrupts`
- However, the resume flow (`resume_agent_chat`) was missing this check
- When a new `interrupt()` was triggered after resume, the frontend never received the new `human_approval_required` message, causing the conversation to appear stuck

## Fix
Added `check_and_handle_interrupts` call to `resume_agent_chat` function after stream ends, making it consistent with the main chat flow.

```python
# Added in resume_agent_chat after stream loop:
langgraph_config = {"configurable": input_context}
async for chunk in check_and_handle_interrupts(
    agent, langgraph_config, make_resume_chunk, meta, thread_id
):
    yield chunk
```

## Testing
- [ ] Tested in Docker environment
- [x] Related functionality works correctly

**Note**: This fix ensures that when an agent triggers multiple Human in the loop approvals in a single conversation, each subsequent approval request is properly sent to the frontend.

## Related Issue
Closes #453