### PR TITLE
fix: 修复新增对话时内容直接作为标题长度超出表字段长度限制问题， titile 字段长度限制为255

### DIFF
--- a/test/test_conversation_repository.py
+++ b/test/test_conversation_repository.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from src.repositories.conversation_repository import ConversationRepository, MAX_CONVERSATION_TITLE_LENGTH
+
+
+def test_normalize_title_truncates_when_too_long():
+    repo = ConversationRepository(None)  # type: ignore[arg-type]
+    raw = "a" * (MAX_CONVERSATION_TITLE_LENGTH + 50)
+
+    normalized = repo._normalize_title(raw)
+
+    assert normalized is not None
+    assert len(normalized) == MAX_CONVERSATION_TITLE_LENGTH
+    assert normalized == "a" * MAX_CONVERSATION_TITLE_LENGTH
+
+
+def test_normalize_title_trims_spaces():
+    repo = ConversationRepository(None)  # type: ignore[arg-type]
+
+    normalized = repo._normalize_title("   hello world   ")
+
+    assert normalized == "hello world"

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -626,12 +626,15 @@ const deleteThread = async (threadId) => {
 const updateThread = async (threadId, title) => {
   if (!threadId || !title) return
 
+  const normalizedTitle = String(title).replace(/\s+/g, ' ').trim().slice(0, 255)
+  if (!normalizedTitle) return
+
   chatState.isRenamingThread = true
   try {
-    await threadApi.updateThread(threadId, title)
+    await threadApi.updateThread(threadId, normalizedTitle)
     const thread = threads.value.find((t) => t.id === threadId)
     if (thread) {
-      thread.title = title
+      thread.title = normalizedTitle
     }
   } catch (error) {
     console.error('Failed to update thread:', error)
@@ -750,7 +753,10 @@ const sendMessage = async ({
 
   // 如果是新对话，用消息内容作为标题
   if ((threadMessages.value[threadId] || []).length === 0) {
-    updateThread(threadId, text)
+    const autoTitle = text.replace(/\s+/g, ' ').trim().slice(0, 255)
+    if (autoTitle) {
+      void updateThread(threadId, autoTitle).catch(() => {})
+    }
   }
 
   const requestData = {


### PR DESCRIPTION
- 新增 MAX_CONVERSATION_TITLE_LENGTH 常量 (255 字符)
- 新增 _normalize_title() 方法用于截断和校验标题
- 防止创建和更新对话时数据库字段溢出
- 前端 AgentChatComponent 同步添加标题标准化处理
- 添加标题标准化的单元测试

## 变更描述
简要描述这个 PR 做了什么

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**


## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范