### PR TITLE
feat: 添加解析URL时文件的判重逻辑

### DIFF
--- a/server/routers/knowledge_router.py
+++ b/server/routers/knowledge_router.py
@@ -334,6 +334,54 @@ async def add_documents(
                 validate_file_path(item, db_id)
             except ValueError as e:
                 raise HTTPException(status_code=403, detail=str(e))
+    
+    async def _handle_file_record(
+        db_id: str,
+        item: str,
+        params: dict,
+        current_user
+    ) -> dict | None:
+        """处理文件记录的添加/覆盖
+
+        Returns:
+            file_meta，如果返回 None 表示跳过该文件
+        """
+        if params and "_preprocessed_map" in params and item in params["_preprocessed_map"]:
+            pre_info = params["_preprocessed_map"][item]
+
+            # 使用预处理信息
+            action = pre_info.get("action", item)  # 通常是原始 URL
+
+            from src.knowledge.utils.kb_utils import parse_minio_url
+            from src.storage.minio import get_minio_client
+
+            minio_client = get_minio_client()
+
+            if action == 'skip':
+                try:
+                    bucket_name, object_name = parse_minio_url(item)
+                    await minio_client.adelete_file(bucket_name, object_name)
+                except Exception as e:
+                    logger.warning(f"Failed to delete MinIO file {item}: {e}")
+                return None
+            elif action == 'overwrite':
+                overwrite_file_id = pre_info.get("overwrite_file_id", item)
+                file_meta_info = await knowledge_base.get_file_basic_info(db_id, overwrite_file_id)
+                overwrite_file_path = file_meta_info.get("meta", {}).get("path")
+                try:
+                    bucket_name, object_name = parse_minio_url(overwrite_file_path)
+                    await minio_client.adelete_file(bucket_name, object_name)
+                    # 删除解析后的 markdown 文件 (kb-parsed/{db_id}/{file_id}/parsed.md)
+                    parsed_object = f"{db_id}/{overwrite_file_id}/parsed.md"
+                    await minio_client.adelete_file(minio_client.KB_BUCKETS["parsed"], parsed_object)
+
+                    await knowledge_base.delete_file_chunks_only(db_id, overwrite_file_id)
+                except Exception as e:
+                    logger.warning(f"Failed to delete MinIO file {item}: {e}")
+
+                return await knowledge_base.update_file_record(db_id, item, params=params, operator_id=current_user.user_id)
+
+        return await knowledge_base.add_file_record(db_id, item, params=params, operator_id=current_user.user_id)
 
     async def run_ingest(context: TaskContext):
         await context.set_message("任务初始化")
@@ -357,9 +405,9 @@ async def add_documents(
 
                 try:
                     # 1. Add file record (UPLOADED)
-                    file_meta = await knowledge_base.add_file_record(
-                        db_id, item, params=params, operator_id=current_user.user_id
-                    )
+                    file_meta = await _handle_file_record(db_id, item, params, current_user)
+                    if file_meta is None:
+                        continue
                     file_id = file_meta["file_id"]
                     added_files[item] = (file_id, file_meta)
                 except Exception as add_error:
@@ -1262,6 +1310,13 @@ async def fetch_url(
             same_name_files = await knowledge_base.get_same_name_files(db_id, url)
             has_same_name = len(same_name_files) > 0
 
+        # 检测相同URL文件
+        same_url_files = []
+        has_same_url = False
+        if db_id:
+            same_url_files = await knowledge_base.get_same_url_files(db_id, final_url)
+            has_same_url = len(same_url_files) > 0
+
         return {
             "status": "success",
             "file_path": upload_result.url,
@@ -1272,6 +1327,8 @@ async def fetch_url(
             "size": len(content_bytes),
             "has_same_name": has_same_name,
             "same_name_files": same_name_files,
+            "has_same_url": has_same_url,
+            "same_url_files": same_url_files,
         }
 
     except HTTPException:

--- a/src/knowledge/base.py
+++ b/src/knowledge/base.py
@@ -228,6 +228,46 @@ class KnowledgeBase(ABC):
         await self._persist_file(file_id)
 
         return metadata
+    
+    async def update_file_record(
+            self, db_id: str, item: str, params: dict | None = None, operator_id: str | None = None
+        ) -> dict:
+            if params and "_preprocessed_map" in params and item in params["_preprocessed_map"]:
+                pre_info = params["_preprocessed_map"][item]
+                file_id = pre_info.get("overwrite_file_id")
+
+            if file_id not in self.files_meta:
+                raise ValueError(f"File {file_id} not found")
+
+            # Get existing metadata
+            existing_metadata = self.files_meta[file_id]
+
+            from src.knowledge.utils.kb_utils import prepare_update_item_metadata
+
+            updating_params = prepare_update_item_metadata(existing_metadata, item, params=params)
+
+            # Only update properties that exist in both params and existing metadata
+            if updating_params:
+                for key, value in updating_params.items():
+                    if key in existing_metadata and key != "processing_params":
+                        existing_metadata[key] = value
+                    elif key == "processing_params":
+                        updating_processing_params = updating_params[key]
+                        for k, v in updating_processing_params.items():
+                            if k in existing_metadata["processing_params"]:
+                                existing_metadata["processing_params"][k] = v
+
+            # Update timestamp and operator
+            existing_metadata["status"] = FileStatus.UPLOADED
+            existing_metadata["updated_at"] = utc_isoformat()
+            if operator_id:
+                existing_metadata["updated_by"] = operator_id
+
+            # Save updated metadata
+            self.files_meta[file_id] = existing_metadata
+            await self._persist_file(file_id)
+
+            return existing_metadata
 
     async def parse_file(self, db_id: str, file_id: str, operator_id: str | None = None) -> dict:
         """

--- a/src/knowledge/manager.py
+++ b/src/knowledge/manager.py
@@ -405,6 +405,13 @@ class KnowledgeBaseManager:
         kb_instance = await self._get_kb_for_database(db_id)
         return await kb_instance.add_file_record(db_id, item, params, operator_id)
 
+    async def update_file_record(
+        self, db_id: str, item: str, params: dict | None = None, operator_id: str | None = None
+    ) -> dict:
+        """Add file record to metadata"""
+        kb_instance = await self._get_kb_for_database(db_id)
+        return await kb_instance.update_file_record(db_id, item, params, operator_id)
+
     async def parse_file(self, db_id: str, file_id: str, operator_id: str | None = None) -> dict:
         """Parse file to Markdown"""
         kb_instance = await self._get_kb_for_database(db_id)
@@ -476,6 +483,11 @@ class KnowledgeBaseManager:
         """删除文件"""
         kb_instance = await self._get_kb_for_database(db_id)
         await kb_instance.delete_file(db_id, file_id)
+
+    async def delete_file_chunks_only(self, db_id: str, file_id: str) -> None:
+        """仅删除文件chunks"""
+        kb_instance = await self._get_kb_for_database(db_id)
+        await kb_instance.delete_file_chunks_only(db_id, file_id)
 
     async def update_content(self, db_id: str, file_ids: list[str], params: dict | None = None) -> list[dict]:
         """更新内容（重新分块）"""
@@ -578,6 +590,59 @@ class KnowledgeBaseManager:
         # 按上传时间降序排序
         same_name_files.sort(key=lambda x: x.get("created_at", ""), reverse=True)
         return same_name_files
+
+    async def get_same_url_files(self, db_id: str, final_url: str) -> list[dict]:
+        """获取同一知识库中相同final_url的文件列表
+        基于processing_params.final_url字段比较
+        返回基础信息：文件名、大小、上传时间、final_url
+
+        Args:
+            db_id: 数据库ID
+            final_url: 要检测的final_url
+
+        Returns:
+            相同URL文件列表，每项包含：
+            - file_id: 文件ID（用于下载）
+            - filename: 文件名
+            - size: 文件大小
+            - created_at: 上传时间
+            - content_hash: 内容哈希
+            - final_url: 原始final_url
+        """
+        if not db_id or not final_url:
+            return []
+        try:
+            kb_instance = await self._get_kb_for_database(db_id)
+        except KBNotFoundError:
+            return []
+
+        same_url_files = []
+        for file_id, file_info in kb_instance.files_meta.items():
+            if file_info.get("database_id") != db_id:
+                continue
+            if file_info.get("status") == "failed":
+                continue
+
+            # 获取processing_params中的final_url字段
+            processing_params = file_info.get("processing_params", {}) or {}
+            current_final_url = processing_params.get("final_url")
+
+            # 如果final_url相同，则认为是重复URL
+            if current_final_url and current_final_url == final_url:
+                same_url_files.append(
+                    {
+                        "file_id": file_id,
+                        "filename": file_info.get("filename", ""),
+                        "size": file_info.get("size", 0),
+                        "created_at": file_info.get("created_at", ""),
+                        "content_hash": file_info.get("content_hash", ""),
+                        "final_url": current_final_url,
+                    }
+                )
+
+        # 按上传时间降序排序
+        same_url_files.sort(key=lambda x: x.get("created_at", ""), reverse=True)
+        return same_url_files
 
     async def file_existed_in_db(self, db_id: str | None, content_hash: str | None) -> bool:
         """检查指定数据库中是否存在相同内容哈希的文件"""

--- a/src/knowledge/utils/kb_utils.py
+++ b/src/knowledge/utils/kb_utils.py
@@ -177,6 +177,30 @@ async def calculate_content_hash(data: bytes | bytearray | str | os.PathLike[str
     # 理论上不会执行到这里，但保留作为防御性编程
     raise TypeError(f"Unsupported data type for hashing: {type(data)!r}")  # type: ignore[unreachable]
 
+def prepare_update_item_metadata(existing_metadata: dict, item: str, params: dict | None = None) -> dict:
+
+    if params and "_preprocessed_map" in params and item in params["_preprocessed_map"]:
+        pre_info = params["_preprocessed_map"][item]
+        filename = pre_info.get("filename", item)  # 通常是原始 URL
+        # 截断文件名以适应数据库限制 (512 chars)，保留部分后缀信息如果可能
+        if len(filename) > 500:
+            filename_display = filename[:400] + "..." + filename[-90:]
+        else:
+            filename_display = filename
+        content_hash = pre_info["content_hash"]
+        # 仅存储需要更新的元数据字段
+        update_metadata = {
+            "filename": filename_display,  # 使用显示用的文件名
+            "path": item,
+            "content_hash": content_hash,
+            "markdown_file": None,
+            "processing_params": {
+                "original_source": item,
+            }
+        }
+        return update_metadata
+
+    return {}
 
 async def prepare_item_metadata(item: str, content_type: str, db_id: str, params: dict | None = None) -> dict:
     """
@@ -204,6 +228,7 @@ async def prepare_item_metadata(item: str, content_type: str, db_id: str, params
         file_type = "html"  # 强制转换为 html 类型，以便后续作为文件处理
         item_path = pre_info["path"]  # MinIO path
         content_hash = pre_info["content_hash"]
+        final_url = pre_info["final_url"]
 
         # 使用 item(url) 生成 ID，保证同一 URL 即使多次添加 ID 也不同（配合 time）
         # 或者我们应该基于 hash？不，基于 time 更符合上传逻辑
@@ -229,6 +254,7 @@ async def prepare_item_metadata(item: str, content_type: str, db_id: str, params
             # 而不是再次尝试作为 URL 抓取
             safe_params["content_type"] = "file"
             safe_params["original_source"] = item  # 保存完整 URL 到 JSON 字段，避免数据库字段长度限制
+            safe_params["final_url"] = final_url # 保存原始的 URL 网址，便于后续判断
             metadata["processing_params"] = safe_params
 
         return metadata

--- a/web/src/components/FileUploadModal.vue
+++ b/web/src/components/FileUploadModal.vue
@@ -12,11 +12,7 @@
             type="primary"
             @click="chunkData"
             :loading="chunkLoading"
-            :disabled="
-              uploadMode === 'url'
-                ? !urlList.some((i) => i.status === 'success')
-                : fileList.length === 0
-            "
+            :disabled="isSubmitDisabled()"
           >
             添加到知识库
           </a-button>
@@ -196,6 +192,27 @@
             <div class="url-content">
               <span class="url-text" :title="item.url">{{ item.url }}</span>
               <span v-if="item.status === 'error'" class="url-error-msg">{{ item.error }}</span>
+
+              <div v-if="item.status === 'success' && item.data?.has_same_url" class="same-url-update-action">
+                <span class="same-url-update-tip">
+                  <Info :size="12" />
+                  <span>知识库中存在相同URL的文件，请选择处理方式：</span>
+                </span>
+                <a-radio-group v-model:value="item.data.action" class="action-radio-group">
+                  <a-radio value="skip">保留原文件</a-radio>
+                  <a-radio value="overwrite">
+                    <span>覆盖原文件</span>
+                    <a-button
+                      type="text"
+                      size="small"
+                      class="action-btn download"
+                      @click="downloadSameNameFile(item.data?.same_url_files?.[0])"
+                    >
+                    <Download :size="14" />
+                    </a-button>
+                  </a-radio>
+                </a-radio-group>
+              </div>
             </div>
             <a-button type="text" size="small" class="remove-url-btn" @click="removeUrl(index)">
               <X :size="14" />
@@ -510,7 +527,7 @@ const handleFetchUrls = async () => {
       item.data = res
 
       // 处理同名文件冲突提示
-      if (res.has_same_name && res.same_name_files && res.same_name_files.length > 0) {
+      if (!res.has_same_url && res.has_same_name && res.same_name_files && res.same_name_files.length > 0) {
         // 合并到现有的同名文件列表中，去重
         const existingIds = new Set(sameNameFiles.value.map((f) => f.file_id))
         const newConflicts = res.same_name_files.filter((f) => !existingIds.has(f.file_id))
@@ -1027,7 +1044,10 @@ const chunkData = async () => {
           path: minioUrl,
           content_hash: item.data.content_hash,
           filename: item.data.filename,
-          file_size: item.data.size
+          file_size: item.data.size,
+          final_url: item.data.final_url,
+          action: item.data.action,
+          overwrite_file_id: item.data.same_url_files?.[0]?.file_id
         }
       }
       params._preprocessed_map = preprocessedMap
@@ -1110,6 +1130,24 @@ const chunkData = async () => {
     store.state.chunkLoading = false
   }
 }
+
+const isSubmitDisabled = () => {
+  // 文件/文件夹模式
+  if (uploadMode.value !== 'url') {
+    return fileList.value.length === 0;
+  }
+
+  const successItems = urlList.value.filter(item => item.status === 'success');
+  if (successItems.length === 0) return true;
+
+  // 检查所有成功项中的冲突项是否已处理
+  const allConflictsHandled = successItems.every(item => {
+    if (!item.data?.has_same_url) return true;
+    return item.data.action; // 要求 action 有值（非空字符串）
+  });
+
+  return !allConflictsHandled;
+};
 </script>
 
 <style lang="less" scoped>
@@ -1505,6 +1543,50 @@ const chunkData = async () => {
   font-size: 11px;
   color: var(--color-error-500);
   margin-top: 2px;
+}
+
+.same-url-update-action {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.same-url-update-tip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-warning-700);
+  border-radius: 16px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.same-url-update-tip .info-icon {
+  color: var(--gray-500);
+}
+
+.action-radio-group {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex: 1;
+  min-width: 200px; 
+}
+
+.action-radio-group .action-btn.download {
+  color: var(--gray-500);
+  margin-left: 4px;
+  padding: 2px 4px;
+  height: auto;
+  line-height: 1;
+}
+
+.same-files-text {
+  color: var(--gray-500);
+  font-size: 12px;
 }
 
 .remove-url-btn {


### PR DESCRIPTION
## 变更描述
功能背景：本次改动旨在避免同一个URL在知识库中被重复解析并存储多份文件。当用户上传一个已存在的URL时，前端将提示用户“保留原文件”或“替换原文件”，确保每个URL在数据库中只对应一份有效数据，同时保留用户对文件版本的控制权。

实现思路：
1、在add_documents时，会将fetch_url步骤中解析的final_url参数传入，并存入数据库文件的processing_params字段中；
2、在fetch_url接口中，会判断当前所上传的数据库文件中是否存在相同final_url的文件，若存在，则将has_same_url字段置为true，并将文件基本数据存储至same_url_files数组中，返回至前端；
3、前端将会显示如下选项供用户选择（same_url展示逻辑高于same_name）：
<img width="799" height="406" alt="image" src="https://github.com/user-attachments/assets/4a2802c5-06d6-41df-919e-83197c4246d3" />
3.1 若选择保留文件，则后端将临时上传至minio的新文件删除，不作其他操作；
3.2 若选择替换文件，则后端将minio原文件、parsed.md、chunks_data删除，并对必要的metadata参数作更新。

## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**


## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范