### PR TITLE
feat: 添加「猜你想问」功能

### DIFF
--- a/server/routers/chat_router.py
+++ b/server/routers/chat_router.py
@@ -890,6 +890,54 @@ async def get_message_feedback(
 
 
 # =============================================================================
+# > === 猜你想问分组 ===
+# =============================================================================
+
+
+@chat.get("/thread/{thread_id}/suggested_questions")
+async def get_suggested_questions(
+    thread_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_required_user),
+):
+    """获取建议问题（需要登录）"""
+    from src.repositories.conversation_repository import ConversationRepository
+    from src.services.suggested_questions_service import get_suggested_questions_by_thread_id
+
+    # 验证会话所有权
+    conv_repo = ConversationRepository(db)
+    conversation = await conv_repo.get_conversation_by_thread_id(thread_id)
+    if not conversation or conversation.user_id != str(current_user.id):
+        raise HTTPException(status_code=404, detail="对话线程不存在")
+
+    result = await get_suggested_questions_by_thread_id(thread_id)
+    return result
+
+
+@chat.post("/thread/{thread_id}/suggested_questions/refresh")
+async def refresh_suggested_questions(
+    thread_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_required_user),
+):
+    """重新生成建议问题（需要登录）- 异步执行"""
+    from src.repositories.conversation_repository import ConversationRepository
+    from src.services.suggested_questions_service import generate_suggested_questions_safe
+
+    # 验证会话所有权
+    conv_repo = ConversationRepository(db)
+    conversation = await conv_repo.get_conversation_by_thread_id(thread_id)
+    if not conversation or conversation.user_id != str(current_user.id):
+        raise HTTPException(status_code=404, detail="对话线程不存在")
+
+    # 异步生成（内部会检查是否已在生成）
+    import asyncio
+    asyncio.create_task(generate_suggested_questions_safe(thread_id))
+
+    return {"questions": [], "is_generating": True}
+
+
+# =============================================================================
 # > === 多模态图片支持分组 ===
 # =============================================================================
 

--- a/src/services/chat_stream_service.py
+++ b/src/services/chat_stream_service.py
@@ -487,6 +487,11 @@ async def stream_agent_chat(
             config_dict=langgraph_config,
         )
 
+        # 异步生成猜你想问（不阻塞响应）
+        from src.services.suggested_questions_service import generate_suggested_questions_safe
+
+        asyncio.create_task(generate_suggested_questions_safe(thread_id))
+
         yield make_chunk(status="finished", meta=meta)
 
     except (asyncio.CancelledError, ConnectionError) as e:
@@ -628,6 +633,11 @@ async def stream_agent_resume(
             conv_repo=conv_repo,
             config_dict=langgraph_config,
         )
+
+        # 异步生成猜你想问（不阻塞响应）
+        from src.services.suggested_questions_service import generate_suggested_questions_safe
+
+        asyncio.create_task(generate_suggested_questions_safe(thread_id))
 
         yield make_resume_chunk(status="finished", meta=meta)
 

--- a/src/services/suggested_questions_service.py
+++ b/src/services/suggested_questions_service.py
@@ -1,0 +1,256 @@
+"""猜你想问服务 - 基于对话历史生成建议问题"""
+
+import re
+from typing import Any
+
+from sqlalchemy import select
+
+from src import config as conf
+from src.models.chat import select_model
+from src.storage.postgres.manager import pg_manager
+from src.storage.postgres.models_business import Conversation, SuggestedQuestion
+from src.utils.logging_config import logger
+
+# Redis key 前缀
+REDIS_KEY_PREFIX = "suggested_questions:generating:"
+REDIS_KEY_TTL = 300  # 5分钟过期
+
+
+async def _get_redis():
+    """获取 Redis 客户端"""
+    from src.services.run_queue_service import get_redis_client
+
+    return await get_redis_client()
+
+
+async def _try_set_generating(thread_id: str) -> bool:
+    """尝试标记正在生成（原子操作），返回是否成功"""
+    try:
+        redis = await _get_redis()
+        key = f"{REDIS_KEY_PREFIX}{thread_id}"
+        # SETNX: 只有 key 不存在时才设置，返回 1 表示成功，0 表示失败
+        result = await redis.set(key, "1", ex=REDIS_KEY_TTL, nx=True)
+        return result is True or result == 1
+    except Exception as e:
+        logger.warning(f"Redis try_set_generating failed: {e}")
+        return True  # Redis 失败时允许继续，避免阻塞
+
+
+async def _clear_generating(thread_id: str) -> None:
+    """清除生成标记"""
+    try:
+        redis = await _get_redis()
+        key = f"{REDIS_KEY_PREFIX}{thread_id}"
+        await redis.delete(key)
+    except Exception as e:
+        logger.warning(f"Redis clear_generating failed: {e}")
+
+
+async def is_generating(thread_id: str) -> bool:
+    """检查指定会话是否正在生成建议问题"""
+    try:
+        redis = await _get_redis()
+        key = f"{REDIS_KEY_PREFIX}{thread_id}"
+        return await redis.exists(key) > 0
+    except Exception as e:
+        logger.warning(f"Redis is_generating check failed: {e}")
+        return False
+
+
+def extract_questions_by_markers(text: str, max_count: int = 3) -> list[str]:
+    """提取带数字编号的问题"""
+    suggestions = []
+
+    patterns = [
+        # 模式1：问题1：内容
+        r"问题\s*(\d+)\s*[:：]\s*(.+?)(?=\s*(?:问题\s*\d+\s*[:：]|$))",
+        # 模式2：1. 内容
+        r"(?<!\d)(\d+)\s*[\.、:：]\s*(.+?)(?=\s*(?:\d+\s*[\.、:：]|$))",
+        # 模式3：一、内容
+        r"([一二三四五六七八九十百千万]+)[、:：]\s*(.+?)(?=\s*(?:[一二三四五六七八九十百千万]+[、:：]|$))",
+    ]
+
+    for pattern in patterns:
+        if len(suggestions) >= max_count:
+            break
+
+        matches = re.findall(pattern, text, re.DOTALL)
+        for match in matches:
+            if len(suggestions) >= max_count:
+                break
+
+            if isinstance(match, tuple):
+                content = match[1].strip() if len(match) > 1 else match[0].strip()
+            else:
+                content = match.strip()
+
+            if content and content not in suggestions:
+                suggestions.append(content)
+
+    return suggestions[:max_count]
+
+
+async def generate_suggested_questions_by_thread_id(thread_id: str) -> list[str]:
+    """
+    基于对话历史生成建议问题（使用 fast_model）
+
+    Args:
+        thread_id: 会话ID
+
+    Returns:
+        建议问题列表
+    """
+    # 原子操作：尝试标记正在生成，失败说明已有任务在执行
+    if not await _try_set_generating(thread_id):
+        logger.debug(f"已有生成任务在执行: {thread_id}")
+        return []
+    try:
+        async with pg_manager.get_async_session_context() as db:
+            # 获取对话
+            result = await db.execute(select(Conversation).where(Conversation.thread_id == thread_id))
+            conversation = result.scalar_one_or_none()
+            if not conversation:
+                logger.warning(f"Conversation not found for thread_id: {thread_id}")
+                return []
+
+            # 获取对话历史消息（多取一些，因为可能有多个 assistant 消息如 tool_calls）
+            from src.storage.postgres.models_business import Message
+            msg_result = await db.execute(
+                select(Message)
+                .where(Message.conversation_id == conversation.id)
+                .order_by(Message.created_at.desc())
+                .limit(20)
+            )
+            messages = list(reversed(msg_result.scalars().all()))  # 按时间正序
+
+            if not messages:
+                return []
+
+            # 构建对话文本：一个 user 消息 + 该 user 后的最后一个 assistant 消息 = 一轮对话
+            # 从前往后遍历，遇到 user 记录问题，遇到 assistant 时更新当前问题的答案
+            # 这样一个 user 后面的多个 assistant 消息，只有最后一个会被保留
+            recent_dialogues: list[dict] = []
+            for msg in messages:
+                if msg.role == "user":
+                    # 新的一轮对话开始
+                    recent_dialogues.append({"question": msg.content, "answer": ""})
+                elif msg.role == "assistant" and recent_dialogues:
+                    # 更新当前对话的答案（多个 assistant 时只保留最后一个）
+                    recent_dialogues[-1]["answer"] = msg.content
+
+            # 过滤掉没有回答的（可能最后一条是 user 还没回复）
+            dialogues = [d for d in recent_dialogues if d["answer"]]
+            if not dialogues:
+                return []
+
+            # 构建对话文本
+            recent_dialogues = dialogues[-3:]  # 最近3轮
+            dialogue_text = ""
+            for i, d in enumerate(recent_dialogues, 1):
+                dialogue_text += f"\n第{i}轮对话：\n问题：{d['question']}\n回答：{d['answer'][:500]}\n"
+
+            # 获取历史建议问题用于去重
+            existing_sq = await db.execute(
+                select(SuggestedQuestion)
+                .where(SuggestedQuestion.conversation_id == conversation.id)
+            )
+            existing = existing_sq.scalar_one_or_none()
+            recent_questions = existing.questions if existing else []
+
+            # 构建提示词
+            prompt = f"""基于以下的对话历史（共{len(recent_dialogues)}轮对话，按照时间顺序排列，越往后的对话越新，请重点关注最新的对话），生成3个用户接下来可能问的问题：{dialogue_text}
+
+    【重要说明】：
+    1. 请特别关注较新的对话，它们代表了最近的讨论方向
+    2. 生成的问题应该基于整个对话历史，但优先考虑最近对话的延续
+    3. 问题应该自然、相关，能推动对话深入"""
+
+            # 只有在 recent_questions 存在且有足够元素时才添加第4点
+            if recent_questions and len(recent_questions) >= 3:
+                prompt += f"""
+    4. 区别于下列三个问题:{recent_questions[0]}、{recent_questions[1]}、{recent_questions[2]}"""
+
+            # 添加公共部分
+            prompt += """
+    请直接返回3个简短【50字以内】、相关的问题，并严格按照以下格式输出，每个问题一行，不要出现任何的多余解释或词汇：
+        问题1：第一个问题
+        问题2：第二个问题
+        问题3：第三个问题
+    """
+
+            # 使用 fast_model
+            model = select_model(model_spec=conf.fast_model)
+            response = await model.call([{"role": "user", "content": prompt}], stream=False)
+
+            content = response.content if hasattr(response, "content") else str(response)
+            suggestions = extract_questions_by_markers(content, 3)
+
+            # 保存到数据库
+            if suggestions:
+                await _upsert_suggested_questions(db, conversation.id, suggestions)
+
+            return suggestions
+
+    except Exception as e:
+        logger.error(f"生成建议问题失败: {e}")
+        return []
+    finally:
+        # 无论成功失败，都移除标记
+        await _clear_generating(thread_id)
+
+
+async def _upsert_suggested_questions(db, conversation_id: int, questions: list[str]) -> None:
+    """更新或插入建议问题"""
+    result = await db.execute(
+        select(SuggestedQuestion).where(SuggestedQuestion.conversation_id == conversation_id)
+    )
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        existing.questions = questions
+    else:
+        sq = SuggestedQuestion(conversation_id=conversation_id, questions=questions)
+        db.add(sq)
+
+    await db.commit()
+
+
+async def get_suggested_questions_by_thread_id(thread_id: str) -> dict[str, Any]:
+    """
+    获取建议问题
+
+    Returns:
+        {
+            "questions": list[str],  # 建议问题列表
+            "is_generating": bool    # 是否正在生成中
+        }
+    """
+    try:
+        # 先检查是否正在生成
+        generating = await is_generating(thread_id)
+
+        async with pg_manager.get_async_session_context() as db:
+            result = await db.execute(
+                select(SuggestedQuestion)
+                .join(Conversation)
+                .where(Conversation.thread_id == thread_id)
+                .order_by(SuggestedQuestion.updated_at.desc())
+            )
+            sq = result.scalar_one_or_none()
+            questions = sq.questions if sq else []
+
+            return {
+                "questions": questions,
+                "is_generating": generating
+            }
+    except Exception as e:
+        logger.error(f"获取建议问题失败: {e}")
+        return {"questions": [], "is_generating": False}
+
+
+async def generate_suggested_questions_safe(thread_id: str) -> None:
+    """安全的生成建议问题（异步执行，不抛出异常）"""
+    try:
+        await generate_suggested_questions_by_thread_id(thread_id)
+    except Exception as e:
+        logger.error(f"异步生成建议问题失败: {e}")

--- a/src/storage/postgres/manager.py
+++ b/src/storage/postgres/manager.py
@@ -194,6 +194,16 @@ class PostgresManager(metaclass=SingletonMeta):
             "CREATE INDEX IF NOT EXISTS idx_agent_runs_thread_created ON agent_runs(thread_id, created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_agent_runs_status_updated ON agent_runs(status, updated_at)",
             "CREATE INDEX IF NOT EXISTS ix_conversations_is_pinned ON conversations(is_pinned)",
+            """
+            CREATE TABLE IF NOT EXISTS suggested_questions (
+                id SERIAL PRIMARY KEY,
+                conversation_id INTEGER NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+                questions JSONB NOT NULL DEFAULT '[]'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """,
+            "CREATE INDEX IF NOT EXISTS idx_suggested_questions_conversation ON suggested_questions(conversation_id)",
         ]
         async with self.async_engine.begin() as conn:
             for stmt in stmts:

--- a/src/storage/postgres/models_business.py
+++ b/src/storage/postgres/models_business.py
@@ -227,6 +227,9 @@ class Conversation(Base):
     stats = relationship(
         "ConversationStats", back_populates="conversation", uselist=False, cascade="all, delete-orphan"
     )
+    suggested_questions = relationship(
+        "SuggestedQuestion", back_populates="conversation", uselist=False, cascade="all, delete-orphan"
+    )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -586,6 +589,36 @@ class AgentRun(Base):
             "error_message": self.error_message,
             "started_at": format_utc_datetime(self.started_at),
             "finished_at": format_utc_datetime(self.finished_at),
+            "created_at": format_utc_datetime(self.created_at),
+            "updated_at": format_utc_datetime(self.updated_at),
+        }
+
+
+class SuggestedQuestion(Base):
+    """猜你想问的问题表"""
+
+    __tablename__ = "suggested_questions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True, comment="主键ID")
+    conversation_id = Column(
+        Integer,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="对话ID",
+    )
+    questions = Column(JSON, nullable=False, default=list, comment="问题列表（JSON数组）")
+    created_at = Column(DateTime, default=utc_now_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utc_now_naive, onupdate=utc_now_naive, comment="更新时间")
+
+    # Relationships
+    conversation = relationship("Conversation", back_populates="suggested_questions")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "conversation_id": self.conversation_id,
+            "questions": self.questions or [],
             "created_at": format_utc_datetime(self.created_at),
             "updated_at": format_utc_datetime(self.updated_at),
         }

--- a/web/src/apis/agent_api.js
+++ b/web/src/apis/agent_api.js
@@ -358,5 +358,19 @@ export const threadApi = {
    * @returns {Promise}
    */
   deleteThreadAttachment: (threadId, fileId) =>
-    apiDelete(`/api/chat/thread/${threadId}/attachments/${fileId}`)
+    apiDelete(`/api/chat/thread/${threadId}/attachments/${fileId}`),
+
+  /**
+   * 获取建议问题（猜你想问）
+   * @param {string} threadId
+   * @returns {Promise}
+   */
+  getSuggestedQuestions: (threadId) => apiGet(`/api/chat/thread/${threadId}/suggested_questions`),
+
+  /**
+   * 重新生成建议问题（猜你想问）
+   * @param {string} threadId
+   * @returns {Promise}
+   */
+  refreshSuggestedQuestions: (threadId) => apiPost(`/api/chat/thread/${threadId}/suggested_questions/refresh`)
 }

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -92,6 +92,13 @@
                 :is-latest-message="false"
                 :sources="getConversationSources(conv)"
               />
+              <!-- 猜你想问 - 只在最后一个对话完成后显示 -->
+              <SuggestedQuestionsComponent
+                v-if="shouldShowSuggestedQuestions(conv, index)"
+                :thread-id="currentChatId"
+                :show="!isProcessing && conversations.length > 0"
+                @question-click="handleSuggestedQuestionClick"
+              />
             </div>
 
             <!-- 生成中的加载状态 - 增强条件支持主聊天和resume流程 -->
@@ -210,6 +217,7 @@ import AgentInputArea from '@/components/AgentInputArea.vue'
 import AgentMessageComponent from '@/components/AgentMessageComponent.vue'
 import ChatSidebarComponent from '@/components/ChatSidebarComponent.vue'
 import RefsComponent from '@/components/RefsComponent.vue'
+import SuggestedQuestionsComponent from '@/components/SuggestedQuestionsComponent.vue'
 import { PanelLeftOpen, MessageCirclePlus, LoaderCircle, ChevronDown, Bot } from 'lucide-vue-next'
 import { handleChatError, handleValidationError } from '@/utils/errorHandler'
 import { ScrollController } from '@/utils/scrollController'
@@ -464,6 +472,23 @@ const shouldShowRefs = computed(() => {
     )
   }
 })
+
+// 计算是否显示猜你想问组件 - 只在最后一个对话完成后显示
+const shouldShowSuggestedQuestions = (conv, index) => {
+  return (
+    index === conversations.value.length - 1 &&
+    conv.status !== 'streaming' &&
+    !isProcessing.value &&
+    !approvalState.showModal &&
+    currentChatId.value
+  )
+}
+
+// 处理猜你想问点击
+const handleSuggestedQuestionClick = (question) => {
+  userInput.value = question
+  handleSendMessage()
+}
 
 // 当前线程状态的computed属性
 const currentThreadState = computed(() => {

--- a/web/src/components/SuggestedQuestionsComponent.vue
+++ b/web/src/components/SuggestedQuestionsComponent.vue
@@ -1,0 +1,383 @@
+<template>
+  <div class="suggested-questions" v-if="showComponent">
+    <div class="suggested-header">
+      <Lightbulb size="14" class="header-icon" />
+      <span class="header-text">猜你想问</span>
+      <a-button
+        class="refresh-btn"
+        type="link"
+        :icon="h(RefreshCw)"
+        title="换一批"
+        @click="handleRefresh"
+        :disabled="loading"
+        :loading="loading"
+      />
+    </div>
+
+    <!-- Loading状态 -->
+    <div class="loading-container" v-if="loading">
+      <div class="loading-dots">
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="dot"></div>
+      </div>
+      <span class="loading-text">正在生成问题...</span>
+    </div>
+
+    <!-- 正常显示的问题列表 -->
+    <div class="questions-container" v-else-if="questions.length > 0">
+      <div
+        v-for="(question, index) in questions"
+        :key="index"
+        class="question-chip"
+        @click="handleQuestionClick(question)"
+        @mouseenter="hoveredQuestion = index"
+        @mouseleave="hoveredQuestion = null"
+      >
+        <div class="question-text">
+          {{ question }}
+        </div>
+        <ArrowUpRight
+          size="10"
+          class="arrow-icon"
+          :class="{ visible: hoveredQuestion === index }"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, computed, h, onUnmounted } from 'vue'
+import { Lightbulb, ArrowUpRight, RefreshCw } from 'lucide-vue-next'
+import { threadApi } from '@/apis/agent_api'
+
+const props = defineProps({
+  threadId: {
+    type: String,
+    default: null
+  },
+  show: {
+    type: Boolean,
+    default: true
+  }
+})
+
+const emit = defineEmits(['question-click'])
+
+const questions = ref([])
+const loading = ref(false)
+const hoveredQuestion = ref(null)
+const pollingTimer = ref(null)
+
+const showComponent = computed(() => {
+  return props.show && props.threadId && (questions.value.length > 0 || loading.value)
+})
+
+// 停止轮询
+const stopPolling = () => {
+  if (pollingTimer.value) {
+    clearTimeout(pollingTimer.value)
+    pollingTimer.value = null
+  }
+}
+
+// 开始轮询等待生成完成
+const startPolling = () => {
+  stopPolling()
+  const poll = async () => {
+    if (!props.threadId) return
+
+    try {
+      const res = await threadApi.getSuggestedQuestions(props.threadId)
+      if (!res.is_generating) {
+        // 生成完成，更新问题并停止轮询
+        questions.value = res.questions || []
+        loading.value = false
+        stopPolling()
+      } else {
+        // 还在生成中，继续等待
+        pollingTimer.value = setTimeout(poll, 2000)
+      }
+    } catch (error) {
+      console.error('轮询建议问题失败:', error)
+      loading.value = false
+      stopPolling()
+    }
+  }
+  pollingTimer.value = setTimeout(poll, 2000)
+}
+
+const fetchQuestions = async () => {
+  if (!props.threadId) return
+
+  loading.value = true
+  try {
+    const res = await threadApi.getSuggestedQuestions(props.threadId)
+    questions.value = res.questions || []
+
+    // 如果正在生成中，开始轮询
+    if (res.is_generating) {
+      loading.value = true
+      startPolling()
+    } else {
+      loading.value = false
+    }
+  } catch (error) {
+    console.error('获取建议问题失败:', error)
+    questions.value = []
+    loading.value = false
+  }
+}
+
+const handleQuestionClick = (questionText) => {
+  emit('question-click', questionText)
+}
+
+const handleRefresh = async () => {
+  if (!props.threadId || loading.value) return
+
+  loading.value = true
+  try {
+    const res = await threadApi.refreshSuggestedQuestions(props.threadId)
+    questions.value = res.questions || []
+
+    // 如果正在生成中，开始轮询
+    if (res.is_generating) {
+      startPolling()
+    } else {
+      loading.value = false
+    }
+  } catch (error) {
+    console.error('刷新建议问题失败:', error)
+    loading.value = false
+  }
+}
+
+// 监听 threadId 变化
+watch(
+  () => props.threadId,
+  (newThreadId) => {
+    // 切换会话时，先停止之前的轮询
+    stopPolling()
+    if (newThreadId) {
+      questions.value = []
+      fetchQuestions()
+    }
+  },
+  { immediate: true }
+)
+
+// 组件销毁时清理
+onUnmounted(() => {
+  stopPolling()
+})
+
+// 暴露刷新方法供父组件调用
+defineExpose({
+  refresh: fetchQuestions
+})
+</script>
+
+<style lang="less" scoped>
+.suggested-questions {
+  margin: 12px 0 8px 0;
+  padding: 8px 0;
+  border-top: 1px solid var(--gray-100);
+  animation: fadeInUp 0.3s ease-out;
+}
+
+.suggested-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+  font-size: 0.75rem;
+  color: var(--gray-600);
+  font-weight: 500;
+
+  .header-icon {
+    color: var(--main-500);
+    flex-shrink: 0;
+  }
+
+  .header-text {
+    font-size: 0.9rem;
+    letter-spacing: 0.25px;
+    font-weight: bold;
+  }
+}
+
+.refresh-btn {
+  color: var(--gray-600);
+  transition: all 0.2s ease;
+  border-radius: 6px;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    color: var(--main-500);
+    background: var(--main-50);
+    transform: rotate(90deg);
+  }
+
+  &:active {
+    transform: scale(0.9) rotate(90deg);
+  }
+}
+
+.loading-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.loading-dots {
+  display: flex;
+  gap: 3px;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--main-400);
+  animation: dotPulse 1.5s infinite ease-in-out;
+}
+
+.dot:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.loading-text {
+  font-size: 0.7rem;
+  color: var(--gray-500);
+}
+
+.questions-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.question-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: var(--gray-50);
+  border: 1px solid var(--gray-100);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--gray-700);
+  transition: all 0.2s ease;
+  user-select: none;
+  max-width: 100%;
+  box-sizing: border-box;
+
+  &:hover {
+    background: var(--main-25);
+    border-color: var(--main-200);
+    color: var(--main-700);
+    transform: translateY(-1px);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  .question-text {
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .arrow-icon {
+    opacity: 0;
+    color: var(--main-500);
+    transition: all 0.2s ease;
+    transform: translateX(-1px);
+    flex-shrink: 0;
+
+    &.visible {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .suggested-questions {
+    margin: 10px 0 6px 0;
+    padding: 6px 0;
+  }
+
+  .questions-container {
+    gap: 4px;
+  }
+
+  .question-chip {
+    padding: 3px 6px;
+    font-size: 0.75rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .question-chip {
+    .arrow-icon {
+      display: none;
+    }
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dotPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+}
+</style>


### PR DESCRIPTION
## 变更描述
### 功能概述

基于对话历史自动生成用户可能感兴趣的问题建议，提升用户交互体验。当对话完成后，系统会自动分析最近 3 轮对话内容，生成 3 个相关问题供用户快速选择。
<img width="685" height="661" alt="41d8b803-3b26-4f63-8bcf-7b6561f8e029" src="https://github.com/user-attachments/assets/8ce0f94e-2605-48d0-9c64-6194bcd83e0e" />


### 主要变更

#### 后端

**新增服务 `src/services/suggested_questions_service.py`**
- `generate_suggested_questions_by_thread_id()` - 基于对话历史生成建议问题
- `get_suggested_questions_by_thread_id()` - 获取已生成的问题及生成状态
- `is_generating()` - 检查是否正在生成中

**数据库模型 `src/storage/postgres/models_business.py`**
- 新增 `SuggestedQuestion` 表，存储每个会话的建议问题

**API 端点 `server/routers/chat_router.py`**
- `GET /api/chat/thread/{thread_id}/suggested_questions` - 获取建议问题
- `POST /api/chat/thread/{thread_id}/suggested_questions/refresh` - 重新生成

#### 前端

**新增组件 `web/src/components/SuggestedQuestionsComponent.vue`**
- 展示建议问题列表，支持点击发送
- 刷新按钮重新生成问题
- Loading 动画（脉冲圆点效果）
- 轮询机制：当问题正在生成时自动轮询等待

**API 接口 `web/src/apis/agent_api.js`**
- `getSuggestedQuestions(threadId)` / `refreshSuggestedQuestions(threadId)`

---

### 技术细节

#### 同步/异步执行模式兼容

系统支持两种对话执行模式，但猜你想问只需在统一位置触发：

| 模式 | API | 执行方式 | 最终调用 |
|------|-----|---------|---------|
| **同步模式** | `POST /agent/{agent_id}` | 直接返回 SSE 流 | `stream_agent_chat()` |
| **异步模式** | `POST /agent/{agent_id}/runs` | 创建 Run 任务，Worker 消费 | `stream_agent_chat()` |

**统一触发点**：无论是同步还是异步模式，最终都会调用 `stream_agent_chat()` 函数。因此猜你想问的触发逻辑只需在 `stream_agent_chat()` 中实现一处（通过 `asyncio.create_task()` 异步执行），即可同时兼容两种模式。


**Redis 状态同步**：
通过 Redis 实现跨容器的生成状态同步，前端可通过 API 查询当前是否正在生成：

```
Key: suggested_questions:generating:{thread_id}
TTL: 300s（5分钟）
```

1. 后端 `asyncio.create_task()` 异步生成问题（**调用fast_model**），不阻塞主对话响应，并在 Redis 标记，返回 `is_generating` 字段给前端
2. 前端调用 API，发现 `is_generating=true`，开始轮询
```
┌─────────────────────────────────────────────────────────────────┐
│  前端调用 getSuggestedQuestions(threadId)                        │
│  ↓                                                              │
│  返回 { questions: [...], is_generating: true/false }           │
│  ↓                                                              │
│  is_generating=true  →  显示 Loading，每 2s 轮询一次            │
│  is_generating=false →  显示问题列表                            │
└─────────────────────────────────────────────────────────────────┘
```
3. 生成完成，Redis 清除标记，前端轮询结束，获取到问题

**切换会话的处理**：
```javascript
watch(() => props.threadId, (newThreadId) => {
  stopPolling()           // 1. 停止之前的轮询（避免多个轮询同时运行）
  questions.value = []    // 2. 清空旧问题（避免闪烁）
  fetchQuestions()        // 3. 获取新会话的状态
})
```

#### 支持用户手动刷新问题

用户点击「换一批」刷新按钮时，调用 `POST /thread/{thread_id}/suggested_questions/refresh` 接口，该接口在 **API 容器**中直接执行（通过 `asyncio.create_task`），异步模式下，**不在 Worker 容器中执行**。这样设计是因为：
- 刷新是用户主动触发的低频操作
- 避免增加 Worker 队列复杂度
- API 容器可以直接访问数据库和模型服务

---

### 文件变更

```
src/services/suggested_questions_service.py          # 新增核心服务
src/storage/postgres/models_business.py              # 新增 SuggestedQuestion 模型
server/routers/chat_router.py                        # 新增 API 端点
src/services/chat_stream_service.py                  # 统一触发点
web/src/components/SuggestedQuestionsComponent.vue   # 新增前端组件
web/src/apis/agent_api.js                            # 新增 API 方法
```

## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范