### PR TITLE
fix: 修复 sandbox 网络名称不匹配导致 agent 执行超时的问题

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -58,6 +58,7 @@ TAVILY_API_KEY=  # 获取搜索服务的 api key 请访问 https://app.tavily.co
 # SANDBOX_HTTPS_PROXY=http://host.docker.internal:7897
 
 # Docker backend 专用 (used when SANDBOX_PROVISIONER_BACKEND=docker/local)
+# 注意：网络名称已在 docker-compose.yml 中固定为 yuxi-know_app-network
 # SANDBOX_DOCKER_NETWORK=yuxi-know_app-network
 # SANDBOX_DOCKER_THREADS_HOST_PATH=
 # SANDBOX_DOCKER_SANDBOX_PREFIX=yuxi-sandbox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -434,4 +434,4 @@ services:
 networks:
   app-network:
     driver: bridge
-    name: yuxi-know_app-network
+    name: ${SANDBOX_DOCKER_NETWORK:-yuxi-know_app-network}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -434,3 +434,4 @@ services:
 networks:
   app-network:
     driver: bridge
+    name: yuxi-know_app-network


### PR DESCRIPTION
- 在 docker-compose.yml 中显式指定网络名称为 yuxi-know_app-network
- 更新 .env.template 添加说明注释

问题原因：sandbox-provisioner 期望连接到 yuxi-know_app-network 网络， 但 docker compose 默认根据项目目录名创建网络，导致网络名称不匹配，
sandbox 容器无法正确获取端口映射，sandbox_url 为空，所有操作超时。

## 变更描述
简要描述这个 PR 做了什么

## 变更类型
- [ ] 新功能
- [x]  Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x]  相关功能正常工作

**相关日志或者截图**


## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范