### PR TITLE
fix: 修复附件 markdown 读取链路与生产部署挂载

### DIFF
--- a/backend/package/yuxi/agents/state.py
+++ b/backend/package/yuxi/agents/state.py
@@ -16,10 +16,26 @@ def merge_artifacts(existing: list[str] | None, new: list[str] | None) -> list[s
     return list(dict.fromkeys(existing + new))
 
 
+def merge_files(existing: dict | None, new: dict | None) -> dict:
+    """Merge state file dictionaries with latest values winning."""
+    if existing is None:
+        return new or {}
+    if new is None:
+        return existing
+    return existing | new
+
+
+def merge_uploads(existing: list[dict] | None, new: list[dict] | None) -> list[dict]:
+    """Replace uploads with the latest normalized snapshot."""
+    return list(new or existing or [])
+
+
 class BaseState(AgentState):
     """Shared state fields for Yuxi agents."""
 
     artifacts: Annotated[list[str], merge_artifacts]
+    files: Annotated[dict, merge_files]
+    uploads: Annotated[list[dict], merge_uploads]
 
 
 class AgentStatePayload(TypedDict):
@@ -27,4 +43,5 @@ class AgentStatePayload(TypedDict):
 
     todos: list
     files: dict
+    uploads: list[dict]
     artifacts: list[str]

--- a/backend/package/yuxi/services/chat_service.py
+++ b/backend/package/yuxi/services/chat_service.py
@@ -104,14 +104,16 @@ def _build_langfuse_run_context(
 def extract_agent_state(values: dict) -> AgentStatePayload:
     """从 LangGraph state 中提取 agent 状态"""
     if not isinstance(values, dict):
-        return {"todos": [], "files": {}, "artifacts": []}
+        return {"todos": [], "files": {}, "uploads": [], "artifacts": []}
 
     # 直接获取，信任 state 的数据结构
     todos = values.get("todos")
     artifacts = values.get("artifacts")
+    uploads = values.get("uploads")
     result: AgentStatePayload = {
         "todos": list(todos)[:20] if todos else [],
         "files": values.get("files") or {},
+        "uploads": list(uploads) if uploads else [],
         "artifacts": list(artifacts) if artifacts else [],
     }
 

--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -163,6 +163,29 @@ def _build_state_uploads(attachments: list[dict]) -> list[dict]:
     return uploads
 
 
+def _build_state_files(attachments: list[dict]) -> dict[str, dict]:
+    files: dict[str, dict] = {}
+    for attachment in attachments:
+        if attachment.get("status") != "parsed":
+            continue
+
+        file_path = attachment.get("file_path")
+        markdown = attachment.get("markdown")
+        if not isinstance(file_path, str) or not file_path.strip():
+            continue
+        if not isinstance(markdown, str) or not markdown:
+            continue
+
+        uploaded_at = attachment.get("uploaded_at") or utc_isoformat()
+        files[file_path] = {
+            "content": markdown.splitlines(),
+            "created_at": uploaded_at,
+            "modified_at": uploaded_at,
+        }
+
+    return files
+
+
 async def _sync_thread_upload_state(
     *,
     thread_id: str,
@@ -183,6 +206,7 @@ async def _sync_thread_upload_state(
             config=config,
             values={
                 "uploads": _build_state_uploads(attachments),
+                "files": _build_state_files(attachments),
             },
         )
     except Exception as exc:  # noqa: BLE001

--- a/backend/test/integration/api/test_chat_router.py
+++ b/backend/test/integration/api/test_chat_router.py
@@ -5,6 +5,7 @@ Integration tests for chat router endpoints.
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
 import pytest
 from yuxi.agents.backends.sandbox import ensure_thread_dirs, sandbox_user_data_dir, sandbox_workspace_dir
@@ -179,3 +180,45 @@ async def test_save_thread_artifact_to_workspace_rejects_invalid_paths(test_clie
         headers=headers,
     )
     assert directory_response.status_code == 400, directory_response.text
+
+
+async def test_docx_attachment_is_materialized_into_state_files_and_readable(test_client, standard_user):
+    headers = standard_user["headers"]
+    thread_id = await _create_thread_for_user(test_client, headers)
+    docx_path = Path(__file__).resolve().parents[2] / "data" / "测试文档.docx"
+
+    with docx_path.open("rb") as handle:
+        upload_response = await test_client.post(
+            f"/api/chat/thread/{thread_id}/attachments",
+            files={
+                "file": (
+                    docx_path.name,
+                    handle,
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                )
+            },
+            headers=headers,
+        )
+    assert upload_response.status_code == 200, upload_response.text
+
+    attachment = upload_response.json()
+    assert attachment["file_name"] == docx_path.name
+    assert attachment["status"] == "parsed"
+    assert attachment["path"].endswith(".md")
+
+    state_response = await test_client.get(f"/api/chat/thread/{thread_id}/state", headers=headers)
+    assert state_response.status_code == 200, state_response.text
+    agent_state = state_response.json()["agent_state"]
+    files = agent_state["files"]
+    assert attachment["path"] in files, agent_state
+    assert files[attachment["path"]]["content"], files[attachment["path"]]
+
+    content_response = await test_client.get(
+        f"/api/chat/thread/{thread_id}/files/content",
+        params={"path": attachment["path"]},
+        headers=headers,
+    )
+    assert content_response.status_code == 200, content_response.text
+    payload = content_response.json()
+    assert payload["path"] == attachment["path"]
+    assert payload["content"]

--- a/backend/test/unit/services/test_chat_service_sync.py
+++ b/backend/test/unit/services/test_chat_service_sync.py
@@ -133,7 +133,7 @@ async def test_agent_chat_uses_invoke_messages_and_persists_langgraph_state(monk
     assert result["response"] == "Hi from invoke"
     assert result["thread_id"] == "thread-1"
     assert result["request_id"] == "req-1"
-    assert result["agent_state"] == {"todos": ["todo-1"], "files": {}, "artifacts": []}
+    assert result["agent_state"] == {"todos": ["todo-1"], "files": {}, "uploads": [], "artifacts": []}
 
     invoke_messages = calls["invoke_messages"]
     assert isinstance(invoke_messages, list)
@@ -214,3 +214,21 @@ async def test_agent_chat_sync_returns_finished_even_when_state_has_interrupt(mo
     assert result["response"] == "Need input later"
     assert result["thread_id"] == "thread-2"
     assert result["request_id"] == "req-2"
+
+
+def test_extract_agent_state_keeps_uploads_and_files():
+    state = svc.extract_agent_state(
+        {
+            "todos": [{"content": "read attachment", "status": "completed"}],
+            "files": {"/home/gem/user-data/uploads/attachments/demo.md": {"content": ["line1"]}},
+            "uploads": [{"path": "/home/gem/user-data/uploads/attachments/demo.md"}],
+            "artifacts": ["/home/gem/user-data/outputs/result.txt"],
+        }
+    )
+
+    assert state == {
+        "todos": [{"content": "read attachment", "status": "completed"}],
+        "files": {"/home/gem/user-data/uploads/attachments/demo.md": {"content": ["line1"]}},
+        "uploads": [{"path": "/home/gem/user-data/uploads/attachments/demo.md"}],
+        "artifacts": ["/home/gem/user-data/outputs/result.txt"],
+    }

--- a/backend/test/unit/services/test_conversation_service_attachment_state.py
+++ b/backend/test/unit/services/test_conversation_service_attachment_state.py
@@ -68,8 +68,10 @@ async def test_sync_thread_attachment_state_updates_graph(monkeypatch: pytest.Mo
         {
             "status": "parsed",
             "path": "/home/gem/user-data/uploads/attachments/resume.md",
+            "file_path": "/home/gem/user-data/uploads/attachments/resume.md",
             "file_name": "resume.md",
             "uploaded_at": "2026-02-20T00:00:00+00:00",
+            "markdown": "# Resume\ncontent",
         }
     ]
     await svc._sync_thread_upload_state(
@@ -80,7 +82,10 @@ async def test_sync_thread_attachment_state_updates_graph(monkeypatch: pytest.Mo
     )
 
     assert captured["write_config"] == {"configurable": {"thread_id": "thread-1", "user_id": "u1"}}
-    assert captured["write_values"] == {"uploads": svc._build_state_uploads(attachments)}
+    assert captured["write_values"] == {
+        "uploads": svc._build_state_uploads(attachments),
+        "files": svc._build_state_files(attachments),
+    }
 
 
 @pytest.mark.asyncio

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -19,16 +19,16 @@ ENV TZ=Asia/Shanghai \
 RUN npm config set registry https://registry.npmmirror.com --global \
     && npm cache clean --force
 
-# 设置代理和时区，更换镜像源，安装系统依赖 - 合并为一个RUN减少层数
+# 设置代理和时区，更换软件源协议并安装系统依赖 - 合并为一个RUN减少层数
 RUN set -ex \
     # (A) 设置时区
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
-    # (B) 替换清华源 (针对 Debian Bookworm 的新版格式)
-    && sed -i 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources \
-    && sed -i 's|security.debian.org/debian-security|mirrors.tuna.tsinghua.edu.cn/debian-security|g' /etc/apt/sources.list.d/debian.sources \
+    # (B) 切换到 https 并启用重试，减少大包下载中断导致的构建失败
+    && sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
+    && sed -i 's|http://security.debian.org/debian-security|https://security.debian.org/debian-security|g' /etc/apt/sources.list.d/debian.sources \
     # (C) 安装必要的系统库
-    && apt-get update \
-    && apt-get install -y --no-install-recommends --fix-missing \
+    && apt-get update -o Acquire::Retries=5 \
+    && apt-get install -y --no-install-recommends --fix-missing -o Acquire::Retries=5 \
         curl \
         ffmpeg \
         git \

--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -29,8 +29,50 @@ cp .env.template .env.prod
 - `NEO4J_PASSWORD`：修改默认密码
 - `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`：修改默认密钥
 - `SILICONFLOW_API_KEY` 等模型密钥
+- `YUXI_SUPER_ADMIN_NAME` / `YUXI_SUPER_ADMIN_PASSWORD`：建议显式配置初始管理员
 
-### 2. 启动服务
+不要把开发或测试环境里的占位值带到生产环境，例如：
+
+- `SILICONFLOW_API_KEY=dummy-for-tests`
+- `TEST_USERNAME`
+- `TEST_PASSWORD`
+
+生产环境必须使用真实可用的模型 provider key，否则聊天链路虽然能启动，实际调用模型时仍会失败。
+
+### 2. 校准默认智能体模型
+
+升级旧实例时，这一步是必须的。
+
+如果数据库中的默认智能体配置仍然指向已经不存在的 provider，例如 `openai_local/gpt-5.4`，容器启动后会在聊天阶段报错：
+
+```text
+Unknown model provider: openai_local
+```
+
+可先进入数据库检查当前配置：
+
+```bash
+docker exec postgres psql -U postgres -d yuxi_know -c \
+  "select id, name, config_json->'context'->>'model' as model, config_json->'context'->>'subagents_model' as subagents_model from agent_configs order by id;"
+```
+
+如果仍是旧 provider，请改成当前系统内置且你已经配置了密钥的模型。以 `siliconflow` 为例：
+
+```bash
+docker exec postgres psql -U postgres -d yuxi_know -c "
+update agent_configs
+set config_json = jsonb_set(
+    jsonb_set(config_json::jsonb, '{context,model}', '\"siliconflow/Pro/deepseek-ai/DeepSeek-V3.2\"'),
+    '{context,subagents_model}',
+    '\"siliconflow/Pro/deepseek-ai/DeepSeek-V3.2\"'
+)::json
+where id = 1;
+"
+```
+
+如果你的默认配置不是 `id = 1`，请按上一步查询结果替换目标记录。
+
+### 3. 启动服务
 
 使用生产环境配置文件启动：
 
@@ -42,10 +84,19 @@ docker compose -f docker-compose.prod.yml up -d --build
 docker compose -f docker-compose.prod.yml --profile all up -d --build
 ```
 
-### 3. 验证部署
+### 4. 验证部署
 
 - Web 访问：http://localhost（直接通过 80 端口）
 - API 健康检查：`curl http://localhost/api/system/health`
+- Docker 状态：`docker ps`
+- API 日志：`docker logs -f api-prod`
+
+建议至少完成一次真实业务验证：
+
+1. 登录系统。
+2. 上传一个 `docx` 文件，确认附件状态为 `parsed`。
+3. 发送“请读取我刚上传的文档并总结”。
+4. 确认智能体能继续读取转换出的 `.md` 文件，而不是只在文件树中显示。
 
 ## 维护与更新
 
@@ -55,9 +106,29 @@ docker compose -f docker-compose.prod.yml --profile all up -d --build
 # 拉取最新代码
 git pull
 
-# 重新构建并启动
+# 重新构建并启动生产容器
 docker compose -f docker-compose.prod.yml up -d --build
 ```
+
+### 从旧版本升级到新版本
+
+如果机器上已经跑着旧版容器，推荐按下面的顺序切换，避免混用旧网络和旧镜像：
+
+```bash
+# 进入新代码目录
+cd /path/to/Yuxi
+
+# 准备并检查生产环境变量
+cp .env.template .env.prod
+
+# 停掉旧的生产容器
+docker compose -f docker-compose.prod.yml down
+
+# 构建并启动新版本
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+如果你是从开发 compose 切到生产 compose，也应确保当前运行中的容器来自同一套 compose 文件，不要让旧的 `api-dev` 和新的 `api-prod` 同时接管同一份生产数据目录。
 
 ### 查看日志
 

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -2,6 +2,14 @@
 
 本页用于记录各版本发布说明（新增、修复与破坏性变更）。
 
+## v0.6.1
+
+### 修复
+
+- 修复聊天附件状态同步链路：上传文件转换出的 Markdown 现在会同步写入 LangGraph `files/uploads` 状态，附件不再只显示在文件树中，智能体也能在对话执行时稳定感知并读取附件。
+- 修复生产部署中的 sandbox provisioner 挂载配置错误：正式环境改为挂载当前项目实际 `saves` 目录，避免附件 Markdown 已生成但 sandbox 内不可见，导致 `read_file('/home/gem/user-data/uploads/attachments/*.md')` 返回 404。
+- 补充附件读取回归测试：新增附件状态同步、聊天接口和端到端验证，覆盖“上传 office 文件 -> 转换 Markdown -> 智能体读取附件”的完整链路。
+
 ## v0.6 (2026-04-01)
 
 

--- a/docs/develop-guides/roadmap.md
+++ b/docs/develop-guides/roadmap.md
@@ -19,6 +19,7 @@
 ### Bugs
 - 目前的知识库的图片存在公开访问风险
 - 生成基准测试会把所有的向量都计算一遍不合理
+- 登录失败分支调用了不存在的 `increment_failed_login()`，当前密码错误场景会直接抛出属性错误，尚未修复
 
 ### BREAKING CHANGE（不兼容变更，0.7 版本再实现）
 - 将自定义provider 的实现逻辑，从文件移动到数据库中，并将相关处理代码，移出 config 文件，放到 provider 模块中
@@ -38,6 +39,7 @@
 - 将 `yuxi` 从 uv workspace 成员调整为 `backend/package` 下可独立构建的本地 Python 包，backend 通过 path dependency 以已安装包形式发现依赖，移除对 `PYTHONPATH=/app/package` 的运行时耦合。
 - 修复沙盒 `workspace` 隔离粒度：宿主机目录从共享 `saves/threads/shared/workspace` 收敛为用户级 `saves/threads/shared/<user_id>/workspace`，并同步传递 `user_id` 到 sandbox 路径解析、provisioner 挂载与 viewer/chat 测试，保证同用户跨线程共享、不同用户隔离。
 - 调整输入框 `@` 提及中的文件搜索交互：无查询内容时不再直接展示文件列表，改为提示“输入相关内容以搜索文件”，避免未过滤结果干扰选择。
+- 修复聊天附件状态同步：上传文件转换出的 markdown 现在会同步写入 LangGraph `files/uploads` 状态，避免附件只显示在文件树里、但智能体状态中缺失导致 `read_file` 无法稳定读取。
 - 收紧文件系统安全边界：viewer/chat 下载与删除路径统一基于解析后的真实路径做允许目录校验，阻止通过软链接逃逸工作区/线程目录；同时将密码哈希默认实现升级为 Argon2，并移除 skill frontmatter 解析中的正则回溯风险。
 - 调整 Skills 导入能力：`/api/system/skills/import` 现在除 ZIP 外也支持直接上传单个 `SKILL.md`，前端上传入口与后端导入服务同步兼容，便于快速导入单文件技能
 - 扩展 viewer 工作区文件操作：`/home/gem/user-data/workspace` 支持从文件系统面板新建文件夹和上传文件，后端限制写入范围并保持同名冲突直接报错。


### PR DESCRIPTION
  修复聊天附件 markdown 读取失败的问题，并补充生产部署说明。

  问题现象：
  - 上传 docx 后会生成 attachments/*.md
  - 前端文件树能看到该 md
  - 但智能体后续 read_file('/home/gem/user-data/uploads/attachments/*.md') 可能返回 404，导致无法继续处理附件内容

  本次修复包含：
  - 将上传附件转换出的 markdown 同步写入 LangGraph files/uploads 状态
  - 补充附件状态同步与读取相关单元测试、集成测试
  - 修复生产环境中 sandbox provisioner 挂载错误 saves 目录导致的附件不可见问题
  - 补充生产部署、升级校准和版本记录文档

  已验证：
  - 正式部署环境下 docx 上传后能生成 markdown
  - 智能体可成功读取 /home/gem/user-data/uploads/attachments/*.md
  - 非流式真实聊天请求已返回 finished 并基于附件内容生成回复