### PR TITLE
fix(knowledge): 修复知识库测试问题生成报错 Unknown model provider

### DIFF
--- a/backend/server/routers/knowledge_router.py
+++ b/backend/server/routers/knowledge_router.py
@@ -1102,7 +1102,7 @@ async def generate_sample_questions(
         logger.info(f"开始生成知识库问题，知识库: {db_name}, 文件数量: {len(files_info)}, 问题数量: {count}")
 
         # 选择模型并调用
-        model = select_model()
+        model = select_model(model_spec=config.default_model)
         messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_message}]
         response = await model.call(messages, stream=False)
 
@@ -1523,7 +1523,7 @@ async def generate_description(
     """).strip()
 
     try:
-        model = select_model()
+        model = select_model(model_spec=config.default_model)
         response = await model.call(prompt)
         description = response.content.strip()
         logger.debug(f"Generated description: {description}")

--- a/backend/server/routers/mindmap_router.py
+++ b/backend/server/routers/mindmap_router.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 
 from yuxi.storage.postgres.models_business import User
 from server.utils.auth_middleware import get_admin_user
-from yuxi import knowledge_base
+from yuxi import config, knowledge_base
 from yuxi.models import select_model
 from yuxi.utils import logger
 
@@ -214,7 +214,7 @@ async def generate_mindmap(
         logger.info(f"开始生成思维导图，知识库: {db_name}, 文件数量: {len(files_info)}")
 
         # 选择模型并调用
-        model = select_model()
+        model = select_model(model_spec=config.default_model)
         messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_message}]
         response = await model.call(messages, stream=False)
 


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么

select_model() 无参调用走了 V1 旧逻辑，无法正确解析 V2 格式的
default_model 配置（如 supreme_newapi:openai）。传入
config.default_model 作为 model_spec 参数，使模型选择走 V2 路径。

影响范围：知识库测试问题生成、知识库描述生成、思维导图生成

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**


## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范