### PR TITLE
fix(knowledge): 修复语言模型选择后无法回显且提交为空

### DIFF
--- a/web/src/components/DatabaseHeader.vue
+++ b/web/src/components/DatabaseHeader.vue
@@ -75,7 +75,7 @@
 import { ref, reactive, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDatabaseStore } from '@/stores/database'
-import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor } from '@/utils/kb_utils'
+import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor, parseModelSpec, buildDisplaySpec } from '@/utils/kb_utils'
 import { LeftOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons-vue'
 import HeaderComponent from '@/components/HeaderComponent.vue'
 import ModelSelectorComponent from '@/components/ModelSelectorComponent.vue'
@@ -94,6 +94,7 @@ const editForm = reactive({
   name: '',
   description: '',
   llm_info: {
+    model_spec: '',
     provider: '',
     model_name: ''
   }
@@ -113,6 +114,7 @@ const showEditModal = () => {
   // 如果是 LightRAG 类型，加载当前的 LLM 配置
   if (database.value.kb_type === 'lightrag') {
     const llmInfo = database.value.llm_info || {}
+    editForm.llm_info.model_spec = llmInfo.model_spec || ''
     editForm.llm_info.provider = llmInfo.provider || ''
     editForm.llm_info.model_name = llmInfo.model_name || ''
   }
@@ -131,6 +133,7 @@ const handleEditSubmit = () => {
       // 如果是 LightRAG 类型，包含 llm_info
       if (database.value.kb_type === 'lightrag') {
         updateData.llm_info = {
+          model_spec: editForm.llm_info.model_spec,
           provider: editForm.llm_info.provider,
           model_name: editForm.llm_info.model_name
         }
@@ -145,25 +148,12 @@ const handleEditSubmit = () => {
 }
 
 // LLM 模型选择处理
-const llmModelSpec = computed(() => {
-  const provider = editForm.llm_info?.provider || ''
-  const modelName = editForm.llm_info?.model_name || ''
-  if (provider && modelName) {
-    return `${provider}/${modelName}`
-  }
-  return ''
-})
+const llmModelSpec = computed(() => buildDisplaySpec(editForm.llm_info))
 
 const handleLLMSelect = (spec) => {
-  console.log('LLM选择:', spec)
-  if (typeof spec !== 'string' || !spec) return
-
-  const index = spec.indexOf('/')
-  const provider = index !== -1 ? spec.slice(0, index) : ''
-  const modelName = index !== -1 ? spec.slice(index + 1) : ''
-
-  editForm.llm_info.provider = provider
-  editForm.llm_info.model_name = modelName
+  const parsed = parseModelSpec(spec)
+  if (!parsed) return
+  Object.assign(editForm.llm_info, parsed)
 }
 
 const deleteDatabase = () => {

--- a/web/src/components/DatabaseHeader.vue
+++ b/web/src/components/DatabaseHeader.vue
@@ -75,7 +75,7 @@
 import { ref, reactive, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDatabaseStore } from '@/stores/database'
-import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor, parseModelSpec, buildDisplaySpec } from '@/utils/kb_utils'
+import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor, parseModelSpec, buildDisplaySpec, buildLlmInfoPayload } from '@/utils/kb_utils'
 import { LeftOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons-vue'
 import HeaderComponent from '@/components/HeaderComponent.vue'
 import ModelSelectorComponent from '@/components/ModelSelectorComponent.vue'
@@ -132,11 +132,7 @@ const handleEditSubmit = () => {
 
       // 如果是 LightRAG 类型，包含 llm_info
       if (database.value.kb_type === 'lightrag') {
-        updateData.llm_info = {
-          model_spec: editForm.llm_info.model_spec,
-          provider: editForm.llm_info.provider,
-          model_name: editForm.llm_info.model_name
-        }
+        updateData.llm_info = buildLlmInfoPayload(editForm.llm_info)
       }
 
       await store.updateDatabaseInfo(updateData)

--- a/web/src/components/KnowledgeBaseCard.vue
+++ b/web/src/components/KnowledgeBaseCard.vue
@@ -158,7 +158,7 @@ import { ref, reactive, computed, h, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDatabaseStore } from '@/stores/database'
 import { useUserStore } from '@/stores/user'
-import { getKbTypeLabel, getKbTypeColor, parseModelSpec, buildDisplaySpec } from '@/utils/kb_utils'
+import { getKbTypeLabel, getKbTypeColor, parseModelSpec, buildDisplaySpec, buildLlmInfoPayload } from '@/utils/kb_utils'
 import {
   CHUNK_PRESET_OPTIONS,
   CHUNK_PRESET_LABEL_MAP,
@@ -377,11 +377,7 @@ const handleEditSubmit = () => {
 
       // 如果是 LightRAG 类型，包含 llm_info
       if (database.value.kb_type === 'lightrag') {
-        updateData.llm_info = {
-          model_spec: editForm.llm_info.model_spec,
-          provider: editForm.llm_info.provider,
-          model_name: editForm.llm_info.model_name
-        }
+        updateData.llm_info = buildLlmInfoPayload(editForm.llm_info)
       }
 
       await store.updateDatabaseInfo(updateData)

--- a/web/src/components/KnowledgeBaseCard.vue
+++ b/web/src/components/KnowledgeBaseCard.vue
@@ -158,7 +158,7 @@ import { ref, reactive, computed, h, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDatabaseStore } from '@/stores/database'
 import { useUserStore } from '@/stores/user'
-import { getKbTypeLabel, getKbTypeColor } from '@/utils/kb_utils'
+import { getKbTypeLabel, getKbTypeColor, parseModelSpec, buildDisplaySpec } from '@/utils/kb_utils'
 import {
   CHUNK_PRESET_OPTIONS,
   CHUNK_PRESET_LABEL_MAP,
@@ -264,6 +264,7 @@ const editForm = reactive({
   auto_generate_questions: false,
   chunk_preset_id: 'general',
   llm_info: {
+    model_spec: '',
     provider: '',
     model_name: ''
   },
@@ -296,6 +297,7 @@ const showEditModal = () => {
   // 如果是 LightRAG 类型，加载当前的 LLM 配置
   if (database.value.kb_type === 'lightrag') {
     const llmInfo = database.value.llm_info || {}
+    editForm.llm_info.model_spec = llmInfo.model_spec || ''
     editForm.llm_info.provider = llmInfo.provider || ''
     editForm.llm_info.model_name = llmInfo.model_name || ''
   }
@@ -376,6 +378,7 @@ const handleEditSubmit = () => {
       // 如果是 LightRAG 类型，包含 llm_info
       if (database.value.kb_type === 'lightrag') {
         updateData.llm_info = {
+          model_spec: editForm.llm_info.model_spec,
           provider: editForm.llm_info.provider,
           model_name: editForm.llm_info.model_name
         }
@@ -390,25 +393,12 @@ const handleEditSubmit = () => {
 }
 
 // LLM 模型选择处理
-const llmModelSpec = computed(() => {
-  const provider = editForm.llm_info?.provider || ''
-  const modelName = editForm.llm_info?.model_name || ''
-  if (provider && modelName) {
-    return `${provider}/${modelName}`
-  }
-  return ''
-})
+const llmModelSpec = computed(() => buildDisplaySpec(editForm.llm_info))
 
 const handleLLMSelect = (spec) => {
-  console.log('LLM选择:', spec)
-  if (typeof spec !== 'string' || !spec) return
-
-  const index = spec.indexOf('/')
-  const provider = index !== -1 ? spec.slice(0, index) : ''
-  const modelName = index !== -1 ? spec.slice(index + 1) : ''
-
-  editForm.llm_info.provider = provider
-  editForm.llm_info.model_name = modelName
+  const parsed = parseModelSpec(spec)
+  if (!parsed) return
+  Object.assign(editForm.llm_info, parsed)
 }
 
 const deleteDatabase = () => {

--- a/web/src/utils/kb_utils.js
+++ b/web/src/utils/kb_utils.js
@@ -26,3 +26,25 @@ export const getKbTypeColor = (type) => {
   }
   return colors[type] || 'blue'
 }
+
+// 解析模型 spec 为 { model_spec, provider, model_name }
+// V2 格式: provider_id:model_id（冒号分隔）
+// V1 格式: provider/model_name（斜杠分隔）
+export const parseModelSpec = (spec) => {
+  if (typeof spec !== 'string' || !spec) return null
+  const sep = spec.includes(':') ? ':' : '/'
+  const index = spec.indexOf(sep)
+  return {
+    model_spec: spec,
+    provider: index !== -1 ? spec.slice(0, index) : '',
+    model_name: index !== -1 ? spec.slice(index + 1) : ''
+  }
+}
+
+// 从 llm_info 构造显示用的 spec 字符串
+export const buildDisplaySpec = (llmInfo) => {
+  if (llmInfo?.model_spec) return llmInfo.model_spec
+  const provider = llmInfo?.provider || ''
+  const modelName = llmInfo?.model_name || ''
+  return provider && modelName ? `${provider}/${modelName}` : ''
+}

--- a/web/src/utils/kb_utils.js
+++ b/web/src/utils/kb_utils.js
@@ -29,11 +29,12 @@ export const getKbTypeColor = (type) => {
 
 // 解析模型 spec 为 { model_spec, provider, model_name }
 // V2 格式: provider_id:model_id（冒号分隔）
-// V1 格式: provider/model_name（斜杠分隔）
+// V1 格式: provider/model_name（斜杠分隔，model_name 可包含冒号）
 export const parseModelSpec = (spec) => {
   if (typeof spec !== 'string' || !spec) return null
-  const sep = spec.includes(':') ? ':' : '/'
-  const index = spec.indexOf(sep)
+  const slashIndex = spec.indexOf('/')
+  const colonIndex = spec.indexOf(':')
+  const index = slashIndex !== -1 ? slashIndex : colonIndex
   return {
     model_spec: spec,
     provider: index !== -1 ? spec.slice(0, index) : '',
@@ -47,4 +48,14 @@ export const buildDisplaySpec = (llmInfo) => {
   const provider = llmInfo?.provider || ''
   const modelName = llmInfo?.model_name || ''
   return provider && modelName ? `${provider}/${modelName}` : ''
+}
+
+// 构造提交给后端的 llm_info，避免旧数据写入空 model_spec
+export const buildLlmInfoPayload = (llmInfo) => {
+  const payload = {
+    provider: llmInfo?.provider || '',
+    model_name: llmInfo?.model_name || ''
+  }
+  if (llmInfo?.model_spec) payload.model_spec = llmInfo.model_spec
+  return payload
 }

--- a/web/src/views/DataBaseView.vue
+++ b/web/src/views/DataBaseView.vue
@@ -250,7 +250,7 @@ import ExtensionCardGrid from '@/components/extensions/ExtensionCardGrid.vue'
 import InfoCard from '@/components/shared/InfoCard.vue'
 import dayjs, { parseToShanghai } from '@/utils/time'
 import AiTextarea from '@/components/AiTextarea.vue'
-import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor, parseModelSpec, buildDisplaySpec } from '@/utils/kb_utils'
+import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor, parseModelSpec, buildDisplaySpec, buildLlmInfoPayload } from '@/utils/kb_utils'
 import { CHUNK_PRESET_OPTIONS, getChunkPresetDescription } from '@/utils/chunk_presets'
 
 const route = useRoute()
@@ -458,17 +458,8 @@ const buildRequestData = () => {
 
   if (newDatabase.kb_type === 'lightrag') {
     requestData.additional_params.language = newDatabase.language || 'English'
-    if (newDatabase.llm_info.model_spec) {
-      requestData.llm_info = {
-        model_spec: newDatabase.llm_info.model_spec,
-        provider: newDatabase.llm_info.provider,
-        model_name: newDatabase.llm_info.model_name
-      }
-    } else if (newDatabase.llm_info.provider && newDatabase.llm_info.model_name) {
-      requestData.llm_info = {
-        provider: newDatabase.llm_info.provider,
-        model_name: newDatabase.llm_info.model_name
-      }
+    if (newDatabase.llm_info.model_spec || (newDatabase.llm_info.provider && newDatabase.llm_info.model_name)) {
+      requestData.llm_info = buildLlmInfoPayload(newDatabase.llm_info)
     }
   }
 

--- a/web/src/views/DataBaseView.vue
+++ b/web/src/views/DataBaseView.vue
@@ -250,7 +250,7 @@ import ExtensionCardGrid from '@/components/extensions/ExtensionCardGrid.vue'
 import InfoCard from '@/components/shared/InfoCard.vue'
 import dayjs, { parseToShanghai } from '@/utils/time'
 import AiTextarea from '@/components/AiTextarea.vue'
-import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor } from '@/utils/kb_utils'
+import { getKbTypeLabel, getKbTypeIcon, getKbTypeColor, parseModelSpec, buildDisplaySpec } from '@/utils/kb_utils'
 import { CHUNK_PRESET_OPTIONS, getChunkPresetDescription } from '@/utils/chunk_presets'
 
 const route = useRoute()
@@ -324,6 +324,7 @@ const createEmptyDatabaseForm = () => ({
   chunk_preset_id: 'general',
   language: 'Chinese',
   llm_info: {
+    model_spec: '',
     provider: '',
     model_name: ''
   },
@@ -338,14 +339,7 @@ const selectedPresetDescription = computed(() =>
   getChunkPresetDescription(newDatabase.chunk_preset_id)
 )
 
-const llmModelSpec = computed(() => {
-  const provider = newDatabase.llm_info?.provider || ''
-  const modelName = newDatabase.llm_info?.model_name || ''
-  if (provider && modelName) {
-    return `${provider}/${modelName}`
-  }
-  return ''
-})
+const llmModelSpec = computed(() => buildDisplaySpec(newDatabase.llm_info))
 
 // 支持的知识库类型
 const supportedKbTypes = ref({})
@@ -427,15 +421,9 @@ const handleKbTypeChange = (type) => {
 
 // 处理LLM选择
 const handleLLMSelect = (spec) => {
-  console.log('LLM选择:', spec)
-  if (typeof spec !== 'string' || !spec) return
-
-  const index = spec.indexOf('/')
-  const provider = index !== -1 ? spec.slice(0, index) : ''
-  const modelName = index !== -1 ? spec.slice(index + 1) : ''
-
-  newDatabase.llm_info.provider = provider
-  newDatabase.llm_info.model_name = modelName
+  const parsed = parseModelSpec(spec)
+  if (!parsed) return
+  Object.assign(newDatabase.llm_info, parsed)
 }
 
 // 构建请求数据（只负责表单数据转换）
@@ -470,7 +458,13 @@ const buildRequestData = () => {
 
   if (newDatabase.kb_type === 'lightrag') {
     requestData.additional_params.language = newDatabase.language || 'English'
-    if (newDatabase.llm_info.provider && newDatabase.llm_info.model_name) {
+    if (newDatabase.llm_info.model_spec) {
+      requestData.llm_info = {
+        model_spec: newDatabase.llm_info.model_spec,
+        provider: newDatabase.llm_info.provider,
+        model_name: newDatabase.llm_info.model_name
+      }
+    } else if (newDatabase.llm_info.provider && newDatabase.llm_info.model_name) {
       requestData.llm_info = {
         provider: newDatabase.llm_info.provider,
         model_name: newDatabase.llm_info.model_name


### PR DESCRIPTION
## Summary

- V2 模型 spec 格式为 `provider_id:model_id`（冒号分隔），但 `handleLLMSelect` 使用斜杠拆分，导致 `provider` 和 `model_name` 均为空
- 新增 `model_spec` 字段直接存储完整 spec，抽取 `parseModelSpec`/`buildDisplaySpec` 工具函数统一处理 V1/V2 两种格式
- 涉及 3 个前端组件：新建表单、编辑表单（卡片）、编辑表单（头部）

## Test plan

- [ ] 新建 LightRAG 类型知识库，选择语言模型后验证回显正常
- [ ] 编辑已有 LightRAG 知识库，切换语言模型后验证回显和保存
- [ ] 验证已有知识库（旧 llm_info 格式）编辑时语言模型正常显示