### PR TITLE
fix: 修复知识库检索配置多次保存卡死的问题 (#679)

### DIFF
--- a/backend/server/routers/knowledge_router.py
+++ b/backend/server/routers/knowledge_router.py
@@ -959,9 +959,15 @@ async def update_knowledge_base_query_params(
 
             options = kb_instance.databases_meta[db_id]["query_params"].setdefault("options", {})
             options.update(params)
-            await kb_instance._save_metadata()
+            updated_query_params = kb_instance.databases_meta[db_id]["query_params"]
 
-            logger.info(f"更新知识库 {db_id} 查询参数: {params}")
+        # 直接通过 Repository 更新单条记录，避免调用 _save_metadata() 遍历所有数据库和文件
+        from yuxi.repositories.knowledge_base_repository import KnowledgeBaseRepository
+
+        kb_repo = KnowledgeBaseRepository()
+        await kb_repo.update(db_id, {"query_params": updated_query_params})
+
+        logger.info(f"更新知识库 {db_id} 查询参数: {params}")
 
         return {"message": "success", "data": params}
 


### PR DESCRIPTION
## 问题描述

知识库检索配置保存接口 `update_knowledge_base_query_params` 在多次快速保存时会卡死（#679）。

## 根因分析

在 `backend/server/routers/knowledge_router.py` 中，`update_knowledge_base_query_params` 端点在持有 `knowledge_base._metadata_lock` 的同时调用了 `kb_instance._save_metadata()`。

`_save_metadata()` 是一个**全量保存**方法，会遍历该知识库类型下的**所有数据库**和**所有文件**，为每条记录执行单独的数据库操作。当知识库数据量较大时：

1. 锁持有时间过长（数百条记录 × 多次 DB 操作）
2. 后续保存请求排队等待锁
3. 前端表现为卡死

## 修复方案

将全量 `_save_metadata()` 替换为针对性的单条记录更新，通过 `KnowledgeBaseRepository.update()` 仅更新当前知识库的 `query_params` 字段。

### 变更点

**Before:**
```python
async with knowledge_base._metadata_lock:
    options.update(params)
    await kb_instance._save_metadata()  # 遍历所有 DB 和文件
```

**After:**
```python
async with knowledge_base._metadata_lock:
    options.update(params)
    updated_query_params = kb_instance.databases_meta[db_id]["query_params"]

# 锁外执行针对性 DB 更新
kb_repo = KnowledgeBaseRepository()
await kb_repo.update(db_id, {"query_params": updated_query_params})
```

### 优势

- 锁持有时间从 O(N) 降到 O(1)，N 为知识库中的文件+数据库数量
- 数据库操作从 N+M 次降到 1 次
- 多次快速保存不再相互阻塞

Fixes #679