### PR TITLE
fix(system): 强制以 UTF-8 编码读取系统日志文件，忽略编码错误

### DIFF
--- a/backend/server/routers/system_router.py
+++ b/backend/server/routers/system_router.py
@@ -65,7 +65,8 @@ async def get_system_logs(levels: str | None = None, current_user: User = Depend
         if levels:
             level_filter = set(level.strip().upper() for level in levels.split(",") if level.strip())
 
-        async with aiofiles.open(LOG_FILE) as f:
+        #  修复 GBK 编码报错：强制 utf-8 读取，忽略错误
+        async with aiofiles.open(LOG_FILE, mode='r', encoding='utf-8', errors='ignore') as f:
             # 读取最后1000行
             lines = []
             async for line in f:
@@ -90,7 +91,6 @@ async def get_system_logs(levels: str | None = None, current_user: User = Depend
     except Exception as e:
         logger.error(f"获取系统日志失败: {e}")
         raise HTTPException(status_code=500, detail=f"获取系统日志失败: {str(e)}")
-
 
 # =============================================================================
 # === 信息管理分组 ===


### PR DESCRIPTION
## 变更描述
修复此issue：https://github.com/xerrors/Yuxi/issues/691

## 测试
- [ √] 已在 Docker 环境测试
- [ √] 相关功能正常工作

**相关日志或者截图**
<img width="1599" height="965" alt="image" src="https://github.com/user-attachments/assets/44e237a7-9420-4e38-9c31-12ec95f26155" />
