### PR TITLE
feat(skill): 新增 Agent 会话中安装 Skill 功能

### DIFF
--- a/backend/package/yuxi/agents/toolkits/buildin/__init__.py
+++ b/backend/package/yuxi/agents/toolkits/buildin/__init__.py
@@ -1,9 +1,11 @@
 # buildin 工具包
+from .install_skill import install_skill
 from .tools import ask_user_question, calculator, present_artifacts, query_knowledge_graph, text_to_img_qwen_image
 
 __all__ = [
     "ask_user_question",
     "calculator",
+    "install_skill",
     "present_artifacts",
     "query_knowledge_graph",
     "text_to_img_qwen_image",

--- a/backend/package/yuxi/agents/toolkits/buildin/install_skill.py
+++ b/backend/package/yuxi/agents/toolkits/buildin/install_skill.py
@@ -1,11 +1,9 @@
-"""Agent 会话中安装 Skill 的工具"""
-
-from __future__ import annotations
-
 import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
-from typing import Annotated
+from typing import Annotated, Any
+
+from langchain_core.tools import InjectedToolArg
 
 from langchain.tools import InjectedToolCallId
 from langchain_core.messages import ToolMessage
@@ -23,7 +21,6 @@ from yuxi.utils.logging_config import logger
 
 ADMIN_ROLES = {"admin", "superadmin"}
 
-
 class InstallSkillInput(BaseModel):
     source: str = Field(
         description="Skill 来源，支持两种格式:\n"
@@ -35,16 +32,14 @@ class InstallSkillInput(BaseModel):
         description="Git 安装时指定要安装的 skill slug 列表（至少一个）。Sandbox 路径安装时忽略此参数。"
     )
 
-
-async def _assert_admin(user_id: str) -> None:
+async def _assert_admin(db, user_id: str) -> None:
     """验证用户是管理员，否则抛出 ValueError。"""
-    async with pg_manager.get_async_session_context() as db:
-        repo = UserRepository(db)
-        user = await repo.get_by_user_id(user_id)
-        if user is None:
-            raise ValueError("用户不存在")
-        if user.role not in ADMIN_ROLES:
-            raise ValueError("仅管理员可以安装 skill")
+    repo = UserRepository()
+    user = await repo.get_by_id_with_db(db, int(user_id))
+    if user is None:
+        raise ValueError("用户不存在")
+    if user.role not in ADMIN_ROLES:
+        raise ValueError("仅管理员可以安装 skill")
 
 
 def _download_skill_dir(backend, remote_dir: str, local_dir: Path) -> None:
@@ -62,10 +57,14 @@ def _download_skill_dir(backend, remote_dir: str, local_dir: Path) -> None:
                 (local_dir / PurePosixPath(path).name).write_bytes(resp[0].content)
 
 
-async def _install_skill_from_sandbox(sandbox_path: str, thread_id: str, user_id: str) -> str:
-    """从 Sandbox 路径安装技能。返回最终安装的 slug（可能与传入的不同）。"""
+async def _install_skill_from_sandbox(db, sandbox_path: str, thread_id: str, user_id: str) -> tuple[str, bool]:
+    """从 Sandbox 路径安装 skill。返回 (slug, 是否因冲突被重命名)。"""
     from yuxi.agents.backends.sandbox import ProvisionerSandboxBackend, resolve_virtual_path
-    from yuxi.services.skill_service import import_skill_dir, is_valid_skill_slug
+    from yuxi.services.skill_service import (
+        _parse_skill_markdown,
+        import_skill_dir,
+        is_valid_skill_slug,
+    )
 
     slug = PurePosixPath(sandbox_path.rstrip("/")).name
     if not is_valid_skill_slug(slug):
@@ -95,50 +94,120 @@ async def _install_skill_from_sandbox(sandbox_path: str, thread_id: str, user_id
             if not (staging / "SKILL.md").exists():
                 raise ValueError(f"沙盒路径 {sandbox_path} 中未找到 SKILL.md")
 
-        async with pg_manager.get_async_session_context() as db:
-            result = await import_skill_dir(db, source_dir=staging, created_by=user_id)
-
-    if isinstance(result, Path):
-        return result.name
-    if isinstance(result, str):
-        return result
-    return slug
+        content = (staging / "SKILL.md").read_text(encoding="utf-8")
+        parsed_name, _, _ = _parse_skill_markdown(content)
+        result = await import_skill_dir(db, source_dir=staging, created_by=user_id)
+    return result.slug, result.slug != parsed_name
 
 
-async def _install_git_skills(source: str, skill_names: list[str], created_by: str) -> list[dict]:
-    """从 Git 仓库安装多个 skill。返回结果列表。"""
+async def _enable_skill_in_current_config(db, user_id: str, thread_id: str, skill_slug: str) -> bool:
+    """在当前会话的配置中启用新安装的 skill"""
+    conv_repo = ConversationRepository(db)
+    conv = await conv_repo.get_conversation_by_thread_id(thread_id)
+    if not conv:
+        return False
+        
+    agent_config_id = (conv.extra_metadata or {}).get("agent_config_id")
+    if not agent_config_id:
+        return False
+
+    config_repo = AgentConfigRepository(db)
+    result = await config_repo.add_skills_to_config_json(
+        agent_config_id=agent_config_id, new_slugs=[skill_slug]
+    )
+    return result
+
+
+async def _run_install_task(
+    source: str,
+    runtime: ToolRuntime,
+    tool_call_id: str,
+    skill_names: list[str] | None = None,
+) -> Command:
+    """执行异步安装任务的核心逻辑"""
+    from yuxi.agents.middlewares.skills_middleware import normalize_selected_skills
+    from yuxi.services.skill_service import sync_thread_visible_skills
     from yuxi.services.remote_skill_install_service import install_remote_skills_batch
 
-    async with pg_manager.get_async_session_context() as db:
-        return await install_remote_skills_batch(
-            db, source=source, skills=skill_names, created_by=created_by
-        )
+    user_id = getattr(runtime.context, "user_id", None)
+    thread_id = getattr(runtime.context, "thread_id", None)
+    
+    logger.info(f"DEBUG: install_skill called with user_id={user_id}, thread_id={thread_id}, source={source}")
+    
+    if not user_id or not thread_id:
+        return Command(update={
+            "messages": [ToolMessage(content="错误：无法获取当前会话信息", tool_call_id=tool_call_id)]
+        })
 
+    try:
+        async with pg_manager.get_async_session_context() as db:
+            await _assert_admin(db, user_id)
 
-async def _enable_skill_in_current_config(user_id: str, thread_id: str, slug: str) -> bool:
-    """将 skill slug 原子追加到当前对话使用的 agent config 中。"""
-    async with pg_manager.get_async_session_context() as db:
-        conv_repo = ConversationRepository(db)
-        conv = await conv_repo.get_conversation_by_thread_id(thread_id)
-        if not conv:
-            logger.warning(f"Conversation {thread_id} not found")
-            return False
+            installed_slugs: list[str] = []
+            failed_items: list[dict] = []
+            slug_warnings: list[str] = []
 
-        agent_config_id = (conv.extra_metadata or {}).get("agent_config_id")
-        if not agent_config_id:
-            logger.warning(f"No agent_config_id found for thread {thread_id}")
-            return False
+            if source.startswith("/"):
+                # Sandbox 路径安装
+                actual_slug, was_renamed = await _install_skill_from_sandbox(db, source, thread_id, user_id)
+                installed_slugs = [actual_slug]
+                if was_renamed:
+                    slug_warnings.append(f"⚠️ 技能 slug '{actual_slug}' 已存在，已自动重命名安装")
+            else:
+                # Git 安装
+                _skill_names = skill_names or []
+                if not _skill_names:
+                    return Command(update={
+                        "messages": [ToolMessage(
+                            content="❌ 错误: 从 Git 安装时必须通过 skill_names 指定技能名称",
+                            tool_call_id=tool_call_id,
+                        )]
+                    })
+                results = await install_remote_skills_batch(db, source=source, skills=_skill_names, created_by=user_id)
+                installed_slugs = [r["slug"] for r in results if r.get("success")]
+                failed_items = [r for r in results if not r.get("success")]
 
-        config_repo = AgentConfigRepository(db)
-        result = await config_repo.add_skills_to_config_json(
-            agent_config_id=agent_config_id,
-            new_slugs=[slug],
-        )
-        if result:
-            logger.info(f"Skill '{slug}' added to agent config {agent_config_id}")
-        else:
-            logger.warning(f"Failed to add skill '{slug}' to config {agent_config_id}")
-        return result
+            # 持久化
+            config_success = True
+            if installed_slugs:
+                for slug in installed_slugs:
+                    ok = await _enable_skill_in_current_config(db, user_id, thread_id, slug)
+                    if not ok:
+                        config_success = False
+
+            # 文件同步
+            current_skills = normalize_selected_skills(
+                getattr(runtime.context, "skills", None)
+            )
+            sync_thread_visible_skills(thread_id, current_skills + installed_slugs)
+
+            # 响应
+            lines = []
+            if installed_slugs:
+                lines.append(f"✅ 成功安装并激活技能: {', '.join(installed_slugs)}")
+            for w in slug_warnings:
+                lines.append(w)
+            if failed_items:
+                for item in failed_items:
+                    lines.append(f"❌ 安装失败 ({item['slug']}): {item.get('error', '未知错误')}")
+            if not config_success:
+                lines.append("⚠️ 技能已安装到系统，但在当前会话配置中激活失败")
+            if not installed_slugs and not failed_items:
+                lines.append("ℹ️ 未发现需要安装的技能")
+
+            return Command(update={
+                "activated_skills": installed_slugs,
+                "messages": [ToolMessage(content="\n".join(lines), tool_call_id=tool_call_id)],
+            })
+
+    except Exception as e:
+        logger.exception("install_skill 异常")
+        return Command(update={
+            "messages": [ToolMessage(
+                content=f"❌ 安装异常: {str(e)}",
+                tool_call_id=tool_call_id,
+            )]
+        })
 
 
 @tool(
@@ -147,100 +216,22 @@ async def _enable_skill_in_current_config(user_id: str, thread_id: str, slug: st
     display_name="安装技能",
     args_schema=InstallSkillInput,
 )
-def install_skill(
+async def install_skill(
     source: str,
-    runtime: ToolRuntime,
-    tool_call_id: Annotated[str, InjectedToolCallId],
     skill_names: list[str] | None = None,
+    runtime: ToolRuntime = None,
+    tool_call_id: Annotated[str, InjectedToolCallId] = "",
 ) -> Command:
-    """从 Sandbox 路径或 Git 仓库安装 skill 到平台。
+    """安装新的技能 (Skill) 到系统中。
 
-    管理员安装后自动启用，新对话中立即生效。
+    参数说明:
+    - source: 必填。支持两种格式:
+      1. Sandbox 路径: 例如 "/tmp/my-skill"
+      2. Git 仓库: 例如 "owner/repo" 或 "https://github.com/owner/repo"
+    - skill_names: 从 Git 仓库安装时必填，指定要安装的技能列表。
 
-    Sandbox 路径（以 / 开头）：
-      指定沙盒中包含 SKILL.md 的目录，支持所有 /home/gem/... 路径。
-      例如 /home/gem/user-data/workspace/my-skill
-
-    Git 仓库（不以 / 开头）：
-      支持 owner/repo 格式或完整 GitHub URL。
-      必须指定 skill_names 选择要安装的 skill，至少一个。
+    注意:
+    - 仅超级管理员 (superadmin) 有权执行此操作。
+    - 安装成功后，该技能会自动在当前会话 (thread) 中激活。
     """
-    import asyncio
-    from yuxi.agents.middlewares.skills_middleware import normalize_selected_skills
-    from yuxi.services.skill_service import sync_thread_visible_skills
-
-    thread_id = getattr(runtime.context, "thread_id", None)
-    user_id = getattr(runtime.context, "user_id", None)
-    if not thread_id or not user_id:
-        return Command(update={
-            "messages": [ToolMessage(content="错误：无法获取当前会话信息", tool_call_id=tool_call_id)]
-        })
-
-    try:
-        asyncio.run(_assert_admin(user_id))
-
-        installed_slugs: list[str] = []
-        failed_items: list[dict] = []
-        slug_warnings: list[str] = []
-
-        if source.startswith("/"):
-            # Sandbox 路径安装
-            original_slug = PurePosixPath(source.strip().rstrip("/")).name
-            actual_slug = asyncio.run(_install_skill_from_sandbox(source, thread_id, user_id))
-            installed_slugs = [actual_slug]
-            if actual_slug != original_slug:
-                slug_warnings.append(f"⚠️ 技能 '{original_slug}' 已存在，已安装为 '{actual_slug}'")
-        else:
-            # Git 仓库安装
-            _skill_names = skill_names or []
-            if not _skill_names:
-                return Command(update={
-                    "messages": [ToolMessage(
-                        content=f"❌ Git 安装需要指定 skill_names 参数。\n"
-                                f"在沙盒中执行 'npx skills list --source {source}' "
-                                f"查看可用的 skill 列表。",
-                        tool_call_id=tool_call_id,
-                    )]
-                })
-            results = asyncio.run(_install_git_skills(source, _skill_names, user_id))
-            installed_slugs = [r["slug"] for r in results if r.get("success")]
-            failed_items = [r for r in results if not r.get("success")]
-
-        # 持久化：每个成功安装的 skill 单独写入 agent config
-        config_success = True
-        if installed_slugs:
-            for slug in installed_slugs:
-                ok = asyncio.run(_enable_skill_in_current_config(user_id, thread_id, slug))
-                if not ok:
-                    config_success = False
-
-            # 文件同步（传递 current_skills + 新 skills，否则会删除已有的）
-            current_skills = normalize_selected_skills(
-                getattr(runtime.context, "skills", None)
-            )
-            sync_thread_visible_skills(thread_id, current_skills + installed_slugs)
-
-        # 构建返回消息
-        lines: list[str] = []
-        if installed_slugs:
-            lines.append(f"✅ Skill '{', '.join(installed_slugs)}' 安装成功！已启用，所有使用当前配置的对话中自动生效。")
-        for w in slug_warnings:
-            lines.append(w)
-        for r in failed_items:
-            lines.append(f"❌ {r['slug']}: {r.get('error', '未知错误')}")
-        if not config_success:
-            lines.append("⚠️ Skill 已安装但持久化到配置失败，请联系管理员。")
-
-        return Command(update={
-            "activated_skills": installed_slugs,
-            "messages": [ToolMessage(content="\n".join(lines), tool_call_id=tool_call_id)],
-        })
-    except ValueError as e:
-        return Command(update={
-            "messages": [ToolMessage(content=f"❌ 安装失败: {e}", tool_call_id=tool_call_id)]
-        })
-    except Exception as e:
-        logger.exception("install_skill 异常")
-        return Command(update={
-            "messages": [ToolMessage(content=f"❌ 安装异常: {e}", tool_call_id=tool_call_id)]
-        })
+    return await _run_install_task(source, runtime, tool_call_id, skill_names)

--- a/backend/package/yuxi/agents/toolkits/buildin/install_skill.py
+++ b/backend/package/yuxi/agents/toolkits/buildin/install_skill.py
@@ -1,9 +1,7 @@
 import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
-from typing import Annotated, Any
-
-from langchain_core.tools import InjectedToolArg
+from typing import Annotated
 
 from langchain.tools import InjectedToolCallId
 from langchain_core.messages import ToolMessage
@@ -20,17 +18,22 @@ from yuxi.utils.logging_config import logger
 
 
 ADMIN_ROLES = {"admin", "superadmin"}
+SANDBOX_PATH_HINT = (
+    "请使用 /home/gem/user-data/workspace/...、/home/gem/user-data/uploads/... 或 /home/gem/user-data/outputs/..."
+)
+
 
 class InstallSkillInput(BaseModel):
     source: str = Field(
         description="Skill 来源，支持两种格式:\n"
-                    "1. Sandbox 路径: /home/gem/user-data/workspace/my-skill （/ 开头）\n"
-                    "2. Git 仓库: owner/repo 或完整 GitHub URL"
+        "1. Sandbox 路径: /home/gem/user-data/workspace/...、"
+        "/home/gem/user-data/uploads/... 或 /home/gem/user-data/outputs/...（/ 开头）\n"
+        "2. Git 仓库: owner/repo 或完整 GitHub URL"
     )
     skill_names: list[str] | None = Field(
-        default=None,
-        description="Git 安装时指定要安装的 skill slug 列表（至少一个）。Sandbox 路径安装时忽略此参数。"
+        default=None, description="Git 安装时指定要安装的 skill slug 列表（至少一个）。Sandbox 路径安装时忽略此参数。"
     )
+
 
 async def _assert_admin(db, user_id: str) -> None:
     """验证用户是管理员，否则抛出 ValueError。"""
@@ -42,27 +45,53 @@ async def _assert_admin(db, user_id: str) -> None:
         raise ValueError("仅管理员可以安装 skill")
 
 
-def _download_skill_dir(backend, remote_dir: str, local_dir: Path) -> None:
-    """递归通过沙盒 API 下载 skill 目录到本地。"""
+def _collect_sandbox_file_paths(backend, remote_dir: str) -> list[str]:
     entries = backend.ls_info(remote_dir)
+    file_paths: list[str] = []
     for entry in entries:
         path = entry["path"]
         if entry.get("is_dir"):
-            sub = local_dir / PurePosixPath(path).name
-            sub.mkdir(parents=True, exist_ok=True)
-            _download_skill_dir(backend, path, sub)
+            file_paths.extend(_collect_sandbox_file_paths(backend, path))
         else:
-            resp = backend.download_files([path])
-            if resp and not resp[0].error:
-                (local_dir / PurePosixPath(path).name).write_bytes(resp[0].content)
+            file_paths.append(path)
+    return file_paths
 
 
-async def _install_skill_from_sandbox(db, sandbox_path: str, thread_id: str, user_id: str) -> tuple[str, bool]:
-    """从 Sandbox 路径安装 skill。返回 (slug, 是否因冲突被重命名)。"""
+def _download_skill_dir(backend, remote_dir: str, local_dir: Path) -> None:
+    """递归通过沙盒 API 下载 skill 目录到本地。"""
+    remote_root = PurePosixPath(remote_dir.rstrip("/"))
+    file_paths = _collect_sandbox_file_paths(backend, remote_dir)
+    if not file_paths:
+        raise ValueError(f"沙盒路径 {remote_dir} 中未发现可下载文件")
+
+    responses = backend.download_files(file_paths)
+    if len(responses) != len(file_paths):
+        raise ValueError("沙盒文件下载结果数量不匹配")
+
+    for expected_path, response in zip(file_paths, responses):
+        error = getattr(response, "error", None)
+        content = getattr(response, "content", None)
+        if error or content is None:
+            raise ValueError(f"下载沙盒文件失败: {expected_path} ({error or 'empty_content'})")
+
+        pure_path = PurePosixPath(expected_path)
+        try:
+            relative_path = pure_path.relative_to(remote_root)
+        except ValueError:
+            relative_path = PurePosixPath(pure_path.name)
+
+        target_path = local_dir / Path(relative_path.as_posix())
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(content)
+
+
+def _prepare_skill_from_sandbox(
+    sandbox_path: str, thread_id: str, user_id: str, staging_root: Path
+) -> tuple[Path, str]:
+    """从 Sandbox 路径准备 skill 目录。返回 (本地目录, 原始 skill name)。"""
     from yuxi.agents.backends.sandbox import ProvisionerSandboxBackend, resolve_virtual_path
     from yuxi.services.skill_service import (
         _parse_skill_markdown,
-        import_skill_dir,
         is_valid_skill_slug,
     )
 
@@ -71,50 +100,42 @@ async def _install_skill_from_sandbox(db, sandbox_path: str, thread_id: str, use
         raise ValueError(f"slug '{slug}' 不合法（仅允许小写字母、数字和连字符）")
 
     if not sandbox_path.startswith("/home/gem/user-data/"):
-        raise ValueError(
-            f"不支持的沙盒路径: {sandbox_path}。"
-            "请使用 /home/gem/user-data/workspace/...、/home/gem/user-data/uploads/... "
-            "或 /home/gem/user-data/outputs/..."
-        )
+        raise ValueError(f"不支持的沙盒路径: {sandbox_path}。{SANDBOX_PATH_HINT}")
 
-    with tempfile.TemporaryDirectory(prefix=".skill-install-") as tmp:
-        staging = Path(tmp) / slug
+    staging = staging_root / slug
 
-        # 优先尝试共享卷路径（性能更好，无需走沙盒 API）
-        try:
-            local_path = resolve_virtual_path(thread_id, sandbox_path, user_id=user_id)
-            if (local_path / "SKILL.md").exists():
-                shutil.copytree(local_path, staging)
-            else:
-                raise FileNotFoundError(f"{local_path} 中未找到 SKILL.md")
-        except (ValueError, FileNotFoundError):
-            staging.mkdir(parents=True, exist_ok=True)
-            backend = ProvisionerSandboxBackend(thread_id=thread_id, user_id=user_id)
-            _download_skill_dir(backend, sandbox_path, staging)
-            if not (staging / "SKILL.md").exists():
-                raise ValueError(f"沙盒路径 {sandbox_path} 中未找到 SKILL.md")
+    # 优先尝试共享卷路径（性能更好，无需走沙盒 API）
+    try:
+        local_path = resolve_virtual_path(thread_id, sandbox_path, user_id=user_id)
+        if (local_path / "SKILL.md").exists():
+            shutil.copytree(local_path, staging)
+        else:
+            raise FileNotFoundError(f"{local_path} 中未找到 SKILL.md")
+    except (ValueError, FileNotFoundError):
+        staging.mkdir(parents=True, exist_ok=True)
+        backend = ProvisionerSandboxBackend(thread_id=thread_id, user_id=user_id)
+        _download_skill_dir(backend, sandbox_path, staging)
+        if not (staging / "SKILL.md").exists():
+            raise ValueError(f"沙盒路径 {sandbox_path} 中未找到 SKILL.md")
 
-        content = (staging / "SKILL.md").read_text(encoding="utf-8")
-        parsed_name, _, _ = _parse_skill_markdown(content)
-        result = await import_skill_dir(db, source_dir=staging, created_by=user_id)
-    return result.slug, result.slug != parsed_name
+    content = (staging / "SKILL.md").read_text(encoding="utf-8")
+    parsed_name, _, _ = _parse_skill_markdown(content)
+    return staging, parsed_name
 
 
-async def _enable_skill_in_current_config(db, user_id: str, thread_id: str, skill_slug: str) -> bool:
+async def _enable_skills_in_current_config(db, thread_id: str, skill_slugs: list[str]) -> bool:
     """在当前会话的配置中启用新安装的 skill"""
     conv_repo = ConversationRepository(db)
     conv = await conv_repo.get_conversation_by_thread_id(thread_id)
     if not conv:
         return False
-        
+
     agent_config_id = (conv.extra_metadata or {}).get("agent_config_id")
     if not agent_config_id:
         return False
 
     config_repo = AgentConfigRepository(db)
-    result = await config_repo.add_skills_to_config_json(
-        agent_config_id=agent_config_id, new_slugs=[skill_slug]
-    )
+    result = await config_repo.add_skills_to_config_json(agent_config_id=agent_config_id, new_slugs=skill_slugs)
     return result
 
 
@@ -126,88 +147,111 @@ async def _run_install_task(
 ) -> Command:
     """执行异步安装任务的核心逻辑"""
     from yuxi.agents.middlewares.skills_middleware import normalize_selected_skills
-    from yuxi.services.skill_service import sync_thread_visible_skills
-    from yuxi.services.remote_skill_install_service import install_remote_skills_batch
+    from yuxi.services.remote_skill_install_service import prepare_remote_skills_batch
+    from yuxi.services.skill_service import import_skill_dir, sync_thread_visible_skills
 
     user_id = getattr(runtime.context, "user_id", None)
     thread_id = getattr(runtime.context, "thread_id", None)
-    
+
     logger.info(f"DEBUG: install_skill called with user_id={user_id}, thread_id={thread_id}, source={source}")
-    
+
     if not user_id or not thread_id:
-        return Command(update={
-            "messages": [ToolMessage(content="错误：无法获取当前会话信息", tool_call_id=tool_call_id)]
-        })
+        return Command(
+            update={"messages": [ToolMessage(content="错误：无法获取当前会话信息", tool_call_id=tool_call_id)]}
+        )
 
     try:
         async with pg_manager.get_async_session_context() as db:
             await _assert_admin(db, user_id)
 
-            installed_slugs: list[str] = []
-            failed_items: list[dict] = []
-            slug_warnings: list[str] = []
+        installed_slugs: list[str] = []
+        failed_items: list[dict] = []
+        slug_warnings: list[str] = []
+        config_success = True
 
-            if source.startswith("/"):
-                # Sandbox 路径安装
-                actual_slug, was_renamed = await _install_skill_from_sandbox(db, source, thread_id, user_id)
-                installed_slugs = [actual_slug]
-                if was_renamed:
-                    slug_warnings.append(f"⚠️ 技能 slug '{actual_slug}' 已存在，已自动重命名安装")
-            else:
-                # Git 安装
-                _skill_names = skill_names or []
-                if not _skill_names:
-                    return Command(update={
-                        "messages": [ToolMessage(
-                            content="❌ 错误: 从 Git 安装时必须通过 skill_names 指定技能名称",
-                            tool_call_id=tool_call_id,
-                        )]
-                    })
-                results = await install_remote_skills_batch(db, source=source, skills=_skill_names, created_by=user_id)
-                installed_slugs = [r["slug"] for r in results if r.get("success")]
-                failed_items = [r for r in results if not r.get("success")]
+        if source.startswith("/"):
+            with tempfile.TemporaryDirectory(prefix=".skill-install-") as tmp:
+                source_dir, parsed_name = _prepare_skill_from_sandbox(source, thread_id, user_id, Path(tmp))
+                async with pg_manager.get_async_session_context() as db:
+                    await _assert_admin(db, user_id)
+                    item = await import_skill_dir(db, source_dir=source_dir, created_by=user_id)
+                    installed_slugs = [item.slug]
+                    if item.slug != parsed_name:
+                        slug_warnings.append(f"⚠️ 技能 slug '{item.slug}' 已存在，已自动重命名安装")
+                    config_success = await _enable_skills_in_current_config(db, thread_id, installed_slugs)
+        else:
+            _skill_names = skill_names or []
+            if not _skill_names:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                content="❌ 错误: 从 Git 安装时必须通过 skill_names 指定技能名称",
+                                tool_call_id=tool_call_id,
+                            )
+                        ]
+                    }
+                )
 
-            # 持久化
-            config_success = True
-            if installed_slugs:
-                for slug in installed_slugs:
-                    ok = await _enable_skill_in_current_config(db, user_id, thread_id, slug)
-                    if not ok:
-                        config_success = False
+            preparation = await prepare_remote_skills_batch(source=source, skills=_skill_names)
+            try:
+                async with pg_manager.get_async_session_context() as db:
+                    await _assert_admin(db, user_id)
+                    for result in preparation.results:
+                        if not result.get("success"):
+                            failed_items.append(result)
+                            continue
 
-            # 文件同步
-            current_skills = normalize_selected_skills(
-                getattr(runtime.context, "skills", None)
-            )
-            sync_thread_visible_skills(thread_id, current_skills + installed_slugs)
+                        try:
+                            item = await import_skill_dir(db, source_dir=result["source_dir"], created_by=user_id)
+                            installed_slugs.append(item.slug)
+                        except Exception as e:
+                            await db.rollback()
+                            failed_items.append({"slug": result["slug"], "success": False, "error": str(e)})
 
-            # 响应
-            lines = []
-            if installed_slugs:
-                lines.append(f"✅ 成功安装并激活技能: {', '.join(installed_slugs)}")
-            for w in slug_warnings:
-                lines.append(w)
-            if failed_items:
-                for item in failed_items:
-                    lines.append(f"❌ 安装失败 ({item['slug']}): {item.get('error', '未知错误')}")
-            if not config_success:
-                lines.append("⚠️ 技能已安装到系统，但在当前会话配置中激活失败")
-            if not installed_slugs and not failed_items:
-                lines.append("ℹ️ 未发现需要安装的技能")
+                    config_success = True
+                    if installed_slugs:
+                        config_success = await _enable_skills_in_current_config(db, thread_id, installed_slugs)
+            finally:
+                preparation.cleanup()
 
-            return Command(update={
+        # 文件同步
+        current_skills = normalize_selected_skills(getattr(runtime.context, "skills", None))
+        sync_thread_visible_skills(thread_id, normalize_selected_skills(current_skills + installed_slugs))
+
+        # 响应
+        lines = []
+        if installed_slugs:
+            lines.append(f"✅ 成功安装并激活技能: {', '.join(installed_slugs)}")
+        for w in slug_warnings:
+            lines.append(w)
+        if failed_items:
+            for item in failed_items:
+                lines.append(f"❌ 安装失败 ({item['slug']}): {item.get('error', '未知错误')}")
+        if not config_success:
+            lines.append("⚠️ 技能已安装到系统，但在当前会话配置中激活失败")
+        if not installed_slugs and not failed_items:
+            lines.append("ℹ️ 未发现需要安装的技能")
+
+        return Command(
+            update={
                 "activated_skills": installed_slugs,
                 "messages": [ToolMessage(content="\n".join(lines), tool_call_id=tool_call_id)],
-            })
+            }
+        )
 
     except Exception as e:
         logger.exception("install_skill 异常")
-        return Command(update={
-            "messages": [ToolMessage(
-                content=f"❌ 安装异常: {str(e)}",
-                tool_call_id=tool_call_id,
-            )]
-        })
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"❌ 安装异常: {str(e)}",
+                        tool_call_id=tool_call_id,
+                    )
+                ]
+            }
+        )
 
 
 @tool(
@@ -226,12 +270,13 @@ async def install_skill(
 
     参数说明:
     - source: 必填。支持两种格式:
-      1. Sandbox 路径: 例如 "/tmp/my-skill"
+      1. Sandbox 路径: /home/gem/user-data/workspace/...、/home/gem/user-data/uploads/...
+         或 /home/gem/user-data/outputs/...
       2. Git 仓库: 例如 "owner/repo" 或 "https://github.com/owner/repo"
     - skill_names: 从 Git 仓库安装时必填，指定要安装的技能列表。
 
     注意:
-    - 仅超级管理员 (superadmin) 有权执行此操作。
+    - 仅管理员 (admin/superadmin) 有权执行此操作。
     - 安装成功后，该技能会自动在当前会话 (thread) 中激活。
     """
     return await _run_install_task(source, runtime, tool_call_id, skill_names)

--- a/backend/package/yuxi/agents/toolkits/buildin/install_skill.py
+++ b/backend/package/yuxi/agents/toolkits/buildin/install_skill.py
@@ -1,0 +1,246 @@
+"""Agent 会话中安装 Skill 的工具"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Annotated
+
+from langchain.tools import InjectedToolCallId
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolRuntime
+from langgraph.types import Command
+from pydantic import BaseModel, Field
+
+from yuxi.agents.toolkits.registry import tool
+from yuxi.repositories.agent_config_repository import AgentConfigRepository
+from yuxi.repositories.conversation_repository import ConversationRepository
+from yuxi.repositories.user_repository import UserRepository
+from yuxi.storage.postgres.manager import pg_manager
+from yuxi.utils.logging_config import logger
+
+
+ADMIN_ROLES = {"admin", "superadmin"}
+
+
+class InstallSkillInput(BaseModel):
+    source: str = Field(
+        description="Skill 来源，支持两种格式:\n"
+                    "1. Sandbox 路径: /home/gem/user-data/workspace/my-skill （/ 开头）\n"
+                    "2. Git 仓库: owner/repo 或完整 GitHub URL"
+    )
+    skill_names: list[str] | None = Field(
+        default=None,
+        description="Git 安装时指定要安装的 skill slug 列表（至少一个）。Sandbox 路径安装时忽略此参数。"
+    )
+
+
+async def _assert_admin(user_id: str) -> None:
+    """验证用户是管理员，否则抛出 ValueError。"""
+    async with pg_manager.get_async_session_context() as db:
+        repo = UserRepository(db)
+        user = await repo.get_by_user_id(user_id)
+        if user is None:
+            raise ValueError("用户不存在")
+        if user.role not in ADMIN_ROLES:
+            raise ValueError("仅管理员可以安装 skill")
+
+
+def _download_skill_dir(backend, remote_dir: str, local_dir: Path) -> None:
+    """递归通过沙盒 API 下载 skill 目录到本地。"""
+    entries = backend.ls_info(remote_dir)
+    for entry in entries:
+        path = entry["path"]
+        if entry.get("is_dir"):
+            sub = local_dir / PurePosixPath(path).name
+            sub.mkdir(parents=True, exist_ok=True)
+            _download_skill_dir(backend, path, sub)
+        else:
+            resp = backend.download_files([path])
+            if resp and not resp[0].error:
+                (local_dir / PurePosixPath(path).name).write_bytes(resp[0].content)
+
+
+async def _install_skill_from_sandbox(sandbox_path: str, thread_id: str, user_id: str) -> str:
+    """从 Sandbox 路径安装技能。返回最终安装的 slug（可能与传入的不同）。"""
+    from yuxi.agents.backends.sandbox import ProvisionerSandboxBackend, resolve_virtual_path
+    from yuxi.services.skill_service import import_skill_dir, is_valid_skill_slug
+
+    slug = PurePosixPath(sandbox_path.rstrip("/")).name
+    if not is_valid_skill_slug(slug):
+        raise ValueError(f"slug '{slug}' 不合法（仅允许小写字母、数字和连字符）")
+
+    if not sandbox_path.startswith("/home/gem/user-data/"):
+        raise ValueError(
+            f"不支持的沙盒路径: {sandbox_path}。"
+            "请使用 /home/gem/user-data/workspace/...、/home/gem/user-data/uploads/... "
+            "或 /home/gem/user-data/outputs/..."
+        )
+
+    with tempfile.TemporaryDirectory(prefix=".skill-install-") as tmp:
+        staging = Path(tmp) / slug
+
+        # 优先尝试共享卷路径（性能更好，无需走沙盒 API）
+        try:
+            local_path = resolve_virtual_path(thread_id, sandbox_path, user_id=user_id)
+            if (local_path / "SKILL.md").exists():
+                shutil.copytree(local_path, staging)
+            else:
+                raise FileNotFoundError(f"{local_path} 中未找到 SKILL.md")
+        except (ValueError, FileNotFoundError):
+            staging.mkdir(parents=True, exist_ok=True)
+            backend = ProvisionerSandboxBackend(thread_id=thread_id, user_id=user_id)
+            _download_skill_dir(backend, sandbox_path, staging)
+            if not (staging / "SKILL.md").exists():
+                raise ValueError(f"沙盒路径 {sandbox_path} 中未找到 SKILL.md")
+
+        async with pg_manager.get_async_session_context() as db:
+            result = await import_skill_dir(db, source_dir=staging, created_by=user_id)
+
+    if isinstance(result, Path):
+        return result.name
+    if isinstance(result, str):
+        return result
+    return slug
+
+
+async def _install_git_skills(source: str, skill_names: list[str], created_by: str) -> list[dict]:
+    """从 Git 仓库安装多个 skill。返回结果列表。"""
+    from yuxi.services.remote_skill_install_service import install_remote_skills_batch
+
+    async with pg_manager.get_async_session_context() as db:
+        return await install_remote_skills_batch(
+            db, source=source, skills=skill_names, created_by=created_by
+        )
+
+
+async def _enable_skill_in_current_config(user_id: str, thread_id: str, slug: str) -> bool:
+    """将 skill slug 原子追加到当前对话使用的 agent config 中。"""
+    async with pg_manager.get_async_session_context() as db:
+        conv_repo = ConversationRepository(db)
+        conv = await conv_repo.get_conversation_by_thread_id(thread_id)
+        if not conv:
+            logger.warning(f"Conversation {thread_id} not found")
+            return False
+
+        agent_config_id = (conv.extra_metadata or {}).get("agent_config_id")
+        if not agent_config_id:
+            logger.warning(f"No agent_config_id found for thread {thread_id}")
+            return False
+
+        config_repo = AgentConfigRepository(db)
+        result = await config_repo.add_skills_to_config_json(
+            agent_config_id=agent_config_id,
+            new_slugs=[slug],
+        )
+        if result:
+            logger.info(f"Skill '{slug}' added to agent config {agent_config_id}")
+        else:
+            logger.warning(f"Failed to add skill '{slug}' to config {agent_config_id}")
+        return result
+
+
+@tool(
+    category="buildin",
+    tags=["skill", "安装"],
+    display_name="安装技能",
+    args_schema=InstallSkillInput,
+)
+def install_skill(
+    source: str,
+    runtime: ToolRuntime,
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    skill_names: list[str] | None = None,
+) -> Command:
+    """从 Sandbox 路径或 Git 仓库安装 skill 到平台。
+
+    管理员安装后自动启用，新对话中立即生效。
+
+    Sandbox 路径（以 / 开头）：
+      指定沙盒中包含 SKILL.md 的目录，支持所有 /home/gem/... 路径。
+      例如 /home/gem/user-data/workspace/my-skill
+
+    Git 仓库（不以 / 开头）：
+      支持 owner/repo 格式或完整 GitHub URL。
+      必须指定 skill_names 选择要安装的 skill，至少一个。
+    """
+    import asyncio
+    from yuxi.agents.middlewares.skills_middleware import normalize_selected_skills
+    from yuxi.services.skill_service import sync_thread_visible_skills
+
+    thread_id = getattr(runtime.context, "thread_id", None)
+    user_id = getattr(runtime.context, "user_id", None)
+    if not thread_id or not user_id:
+        return Command(update={
+            "messages": [ToolMessage(content="错误：无法获取当前会话信息", tool_call_id=tool_call_id)]
+        })
+
+    try:
+        asyncio.run(_assert_admin(user_id))
+
+        installed_slugs: list[str] = []
+        failed_items: list[dict] = []
+        slug_warnings: list[str] = []
+
+        if source.startswith("/"):
+            # Sandbox 路径安装
+            original_slug = PurePosixPath(source.strip().rstrip("/")).name
+            actual_slug = asyncio.run(_install_skill_from_sandbox(source, thread_id, user_id))
+            installed_slugs = [actual_slug]
+            if actual_slug != original_slug:
+                slug_warnings.append(f"⚠️ 技能 '{original_slug}' 已存在，已安装为 '{actual_slug}'")
+        else:
+            # Git 仓库安装
+            _skill_names = skill_names or []
+            if not _skill_names:
+                return Command(update={
+                    "messages": [ToolMessage(
+                        content=f"❌ Git 安装需要指定 skill_names 参数。\n"
+                                f"在沙盒中执行 'npx skills list --source {source}' "
+                                f"查看可用的 skill 列表。",
+                        tool_call_id=tool_call_id,
+                    )]
+                })
+            results = asyncio.run(_install_git_skills(source, _skill_names, user_id))
+            installed_slugs = [r["slug"] for r in results if r.get("success")]
+            failed_items = [r for r in results if not r.get("success")]
+
+        # 持久化：每个成功安装的 skill 单独写入 agent config
+        config_success = True
+        if installed_slugs:
+            for slug in installed_slugs:
+                ok = asyncio.run(_enable_skill_in_current_config(user_id, thread_id, slug))
+                if not ok:
+                    config_success = False
+
+            # 文件同步（传递 current_skills + 新 skills，否则会删除已有的）
+            current_skills = normalize_selected_skills(
+                getattr(runtime.context, "skills", None)
+            )
+            sync_thread_visible_skills(thread_id, current_skills + installed_slugs)
+
+        # 构建返回消息
+        lines: list[str] = []
+        if installed_slugs:
+            lines.append(f"✅ Skill '{', '.join(installed_slugs)}' 安装成功！已启用，所有使用当前配置的对话中自动生效。")
+        for w in slug_warnings:
+            lines.append(w)
+        for r in failed_items:
+            lines.append(f"❌ {r['slug']}: {r.get('error', '未知错误')}")
+        if not config_success:
+            lines.append("⚠️ Skill 已安装但持久化到配置失败，请联系管理员。")
+
+        return Command(update={
+            "activated_skills": installed_slugs,
+            "messages": [ToolMessage(content="\n".join(lines), tool_call_id=tool_call_id)],
+        })
+    except ValueError as e:
+        return Command(update={
+            "messages": [ToolMessage(content=f"❌ 安装失败: {e}", tool_call_id=tool_call_id)]
+        })
+    except Exception as e:
+        logger.exception("install_skill 异常")
+        return Command(update={
+            "messages": [ToolMessage(content=f"❌ 安装异常: {e}", tool_call_id=tool_call_id)]
+        })

--- a/backend/package/yuxi/repositories/agent_config_repository.py
+++ b/backend/package/yuxi/repositories/agent_config_repository.py
@@ -238,16 +238,18 @@ class AgentConfigRepository:
         Returns:
             是否成功更新（至少有一条记录被修改）
         """
+        import json
         sql = text("""
-            UPDATE agent_config
+            UPDATE agent_configs
             SET config_json = jsonb_set(
-                config_json,
+                CAST(config_json AS jsonb),
                 '{skills}',
-                COALESCE(config_json->'skills', '[]'::jsonb) || to_jsonb(:new_slugs::text[])::jsonb,
+                COALESCE(CAST(config_json->'skills' AS jsonb), CAST('[]' AS jsonb)) || CAST(:new_slugs_json AS jsonb),
                 true
             )
             WHERE id = :id
         """)
-        result = await self.db.execute(sql, {"id": agent_config_id, "new_slugs": new_slugs})
+        new_slugs_json = json.dumps(new_slugs)
+        result = await self.db.execute(sql, {"id": agent_config_id, "new_slugs_json": new_slugs_json})
         await self.db.commit()
         return result.rowcount > 0

--- a/backend/package/yuxi/repositories/agent_config_repository.py
+++ b/backend/package/yuxi/repositories/agent_config_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select, update, text
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from yuxi.storage.postgres.models_business import AgentConfig
@@ -8,6 +8,20 @@ from yuxi.utils.datetime_utils import utc_now_naive
 
 # 默认配置名称
 DEFAULT_CONFIG_NAME = "初始配置"
+
+
+def _merge_skill_slugs(current_slugs: object, new_slugs: list[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for value in [*(current_slugs if isinstance(current_slugs, list) else []), *new_slugs]:
+        if not isinstance(value, str):
+            continue
+        slug = value.strip()
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        merged.append(slug)
+    return merged
 
 
 class AgentConfigRepository:
@@ -24,6 +38,10 @@ class AgentConfigRepository:
 
     async def get_by_id(self, config_id: int) -> AgentConfig | None:
         result = await self.db.execute(select(AgentConfig).where(AgentConfig.id == config_id))
+        return result.scalar_one_or_none()
+
+    async def _get_by_id_for_update(self, config_id: int) -> AgentConfig | None:
+        result = await self.db.execute(select(AgentConfig).where(AgentConfig.id == config_id).with_for_update())
         return result.scalar_one_or_none()
 
     async def set_default(self, *, config: AgentConfig, updated_by: str | None = None) -> AgentConfig:
@@ -229,32 +247,26 @@ class AgentConfigRepository:
             await self.set_default(config=remaining[0], updated_by=updated_by)
 
     async def add_skills_to_config_json(self, *, agent_config_id: int, new_slugs: list[str]) -> bool:
-        """使用 PostgreSQL JSONB 原子操作追加 skills。
+        """在 config_json.context.skills 中追加 skills，并保持顺序去重。
 
         Args:
             agent_config_id: AgentConfig 的 ID
             new_slugs: 要追加的技能 slug 列表，会自动去重
 
         Returns:
-            是否成功更新（至少有一条记录被修改）
+            是否找到并更新了配置
         """
-        import json
-        sql = text("""
-            UPDATE agent_configs
-            SET config_json = jsonb_set(
-                COALESCE(CAST(config_json AS jsonb), '{}'::jsonb),
-                '{context}',
-                jsonb_set(
-                    COALESCE(CAST(config_json->'context' AS jsonb), '{}'::jsonb),
-                    '{skills}',
-                    COALESCE(CAST(config_json->'context'->'skills' AS jsonb), CAST('[]' AS jsonb)) || CAST(:new_slugs_json AS jsonb),
-                    true
-                ),
-                true
-            )
-            WHERE id = :id
-        """)
-        new_slugs_json = json.dumps(new_slugs)
-        result = await self.db.execute(sql, {"id": agent_config_id, "new_slugs_json": new_slugs_json})
+        config = await self._get_by_id_for_update(agent_config_id)
+        if not config:
+            return False
+
+        config_json = dict(config.config_json or {})
+        context = dict(config_json.get("context") or {})
+        context["skills"] = _merge_skill_slugs(context.get("skills"), new_slugs)
+        config_json["context"] = context
+
+        config.config_json = config_json
+        config.updated_at = utc_now_naive()
         await self.db.commit()
-        return result.rowcount > 0
+        await self.db.refresh(config)
+        return True

--- a/backend/package/yuxi/repositories/agent_config_repository.py
+++ b/backend/package/yuxi/repositories/agent_config_repository.py
@@ -242,9 +242,14 @@ class AgentConfigRepository:
         sql = text("""
             UPDATE agent_configs
             SET config_json = jsonb_set(
-                CAST(config_json AS jsonb),
-                '{skills}',
-                COALESCE(CAST(config_json->'skills' AS jsonb), CAST('[]' AS jsonb)) || CAST(:new_slugs_json AS jsonb),
+                COALESCE(CAST(config_json AS jsonb), '{}'::jsonb),
+                '{context}',
+                jsonb_set(
+                    COALESCE(CAST(config_json->'context' AS jsonb), '{}'::jsonb),
+                    '{skills}',
+                    COALESCE(CAST(config_json->'context'->'skills' AS jsonb), CAST('[]' AS jsonb)) || CAST(:new_slugs_json AS jsonb),
+                    true
+                ),
                 true
             )
             WHERE id = :id

--- a/backend/package/yuxi/repositories/agent_config_repository.py
+++ b/backend/package/yuxi/repositories/agent_config_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select, update
+from sqlalchemy import select, update, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from yuxi.storage.postgres.models_business import AgentConfig
@@ -227,3 +227,27 @@ class AgentConfigRepository:
 
         if was_default:
             await self.set_default(config=remaining[0], updated_by=updated_by)
+
+    async def add_skills_to_config_json(self, *, agent_config_id: int, new_slugs: list[str]) -> bool:
+        """使用 PostgreSQL JSONB 原子操作追加 skills。
+
+        Args:
+            agent_config_id: AgentConfig 的 ID
+            new_slugs: 要追加的技能 slug 列表，会自动去重
+
+        Returns:
+            是否成功更新（至少有一条记录被修改）
+        """
+        sql = text("""
+            UPDATE agent_config
+            SET config_json = jsonb_set(
+                config_json,
+                '{skills}',
+                COALESCE(config_json->'skills', '[]'::jsonb) || to_jsonb(:new_slugs::text[])::jsonb,
+                true
+            )
+            WHERE id = :id
+        """)
+        result = await self.db.execute(sql, {"id": agent_config_id, "new_slugs": new_slugs})
+        await self.db.commit()
+        return result.rowcount > 0

--- a/backend/package/yuxi/repositories/user_repository.py
+++ b/backend/package/yuxi/repositories/user_repository.py
@@ -5,6 +5,7 @@ from datetime import datetime as dt
 from typing import Annotated, Any
 
 from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from yuxi.storage.postgres.manager import pg_manager
 from yuxi.storage.postgres.models_business import User
@@ -19,14 +20,22 @@ class UserRepository:
     async def get_by_id(self, id: int) -> User | None:
         """根据 ID 获取用户"""
         async with pg_manager.get_async_session_context() as session:
-            result = await session.execute(select(User).where(User.id == id))
-            return result.scalar_one_or_none()
+            return await self.get_by_id_with_db(session, id)
+
+    async def get_by_id_with_db(self, db: AsyncSession, id: int) -> User | None:
+        """使用指定的 db 根据 ID 获取用户"""
+        result = await db.execute(select(User).where(User.id == id))
+        return result.scalar_one_or_none()
 
     async def get_by_user_id(self, user_id: str) -> User | None:
         """根据 user_id 获取用户"""
         async with pg_manager.get_async_session_context() as session:
-            result = await session.execute(select(User).where(User.user_id == user_id))
-            return result.scalar_one_or_none()
+            return await self.get_by_user_id_with_db(session, user_id)
+
+    async def get_by_user_id_with_db(self, db: AsyncSession, user_id: str) -> User | None:
+        """使用指定的 db 获取用户"""
+        result = await db.execute(select(User).where(User.user_id == user_id))
+        return result.scalar_one_or_none()
 
     async def get_by_phone(self, phone: str) -> User | None:
         """根据手机号获取用户"""

--- a/backend/package/yuxi/services/remote_skill_install_service.py
+++ b/backend/package/yuxi/services/remote_skill_install_service.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,16 @@ if TYPE_CHECKING:
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 CONTROL_SEQUENCE_RE = re.compile(r"\x1B\][^\x07]*(?:\x07|\x1B\\)|\x1B[\(\)][A-Za-z0-9]")
 CLI_TIMEOUT_SECONDS = 300
+
+
+@dataclass(slots=True)
+class RemoteSkillsBatchPreparation:
+    temp_home: str | None
+    results: list[dict]
+
+    def cleanup(self) -> None:
+        if self.temp_home:
+            shutil.rmtree(self.temp_home, ignore_errors=True)
 
 
 def _normalize_source(source: str) -> str:
@@ -229,6 +240,37 @@ async def install_remote_skills_batch(
     Returns:
         每个 skill 的安装结果列表，顺序与请求一致: ``[{slug, success, error?}, ...]``
     """
+    preparation = await prepare_remote_skills_batch(source=source, skills=skills)
+    try:
+        results = preparation.results
+        for index, result in enumerate(results):
+            if not result.get("success"):
+                continue
+
+            source_dir = result.get("source_dir")
+            try:
+                item = await import_skill_dir(
+                    db,
+                    source_dir=source_dir,
+                    created_by=created_by,
+                )
+                results[index] = {"slug": item.slug, "success": True}
+            except Exception as e:
+                if hasattr(db, "rollback"):
+                    await db.rollback()
+                results[index] = {"slug": result["slug"], "success": False, "error": str(e)}
+
+        return results
+    finally:
+        preparation.cleanup()
+
+
+async def prepare_remote_skills_batch(
+    *,
+    source: str,
+    skills: list[str],
+) -> RemoteSkillsBatchPreparation:
+    """批量从远程仓库拉取 skill 目录，但不写数据库。"""
     normalized_source = _normalize_source(source)
     if not skills:
         raise ValueError("skills 列表不能为空")
@@ -245,11 +287,10 @@ async def install_remote_skills_batch(
             results[i] = {"slug": skill, "success": False, "error": str(e)}
 
     if not normalized_skills:
-        return results
+        return RemoteSkillsBatchPreparation(temp_home=None, results=results)
 
     temp_home, env, workdir = _create_isolated_workdir()
     try:
-        # Step 1: 一次 npx 调用安装所有 skill（克隆一次）
         skill_args: list[str] = []
         for name in normalized_skills:
             skill_args.extend(["--skill", name])
@@ -275,31 +316,19 @@ async def install_remote_skills_batch(
             # CLI 对不匹配的 skill 会退出码非零，但已安装的目录仍在
             cli_failed = True
 
-        # Step 2: 从临时目录中找到各 skill 的安装目录并逐个导入
-        base_dir = Path(temp_home).resolve()
-        skills_dir = base_dir / ".agents" / "skills"
-
+        skills_dir = Path(temp_home).resolve() / ".agents" / "skills"
         for original_index, name in zip(valid_indices, normalized_skills):
             installed_dir = _find_skill_dir(skills_dir, name)
             if installed_dir is None:
                 error_msg = "CLI 安装失败" if cli_failed else "skills CLI 未生成预期的技能目录"
                 results[original_index] = {"slug": name, "success": False, "error": error_msg}
-                continue
+            else:
+                results[original_index] = {"slug": name, "success": True, "source_dir": installed_dir}
 
-            try:
-                item = await import_skill_dir(
-                    db,
-                    source_dir=installed_dir,
-                    created_by=created_by,
-                )
-                results[original_index] = {"slug": item.slug, "success": True}
-            except Exception as e:
-                await db.rollback()
-                results[original_index] = {"slug": name, "success": False, "error": str(e)}
-
-        return results
-    finally:
+        return RemoteSkillsBatchPreparation(temp_home=temp_home, results=results)
+    except Exception:
         shutil.rmtree(temp_home, ignore_errors=True)
+        raise
 
 
 def _find_skill_dir(skills_dir: Path, name: str) -> Path | None:

--- a/backend/package/yuxi/services/remote_skill_install_service.py
+++ b/backend/package/yuxi/services/remote_skill_install_service.py
@@ -234,7 +234,7 @@ async def install_remote_skills_batch(
         raise ValueError("skills 列表不能为空")
 
     # 预分配结果数组（按请求顺序），校验非法名并记录失败
-    results: list[dict] = [{"slug": "", "success": False, "error": "unset"}] * len(skills)
+    results: list[dict] = [{"slug": "", "success": False, "error": "unset"} for _ in range(len(skills))]
     normalized_skills: list[str] = []
     valid_indices: list[int] = []
     for i, skill in enumerate(skills):

--- a/backend/package/yuxi/storage/postgres/manager.py
+++ b/backend/package/yuxi/storage/postgres/manager.py
@@ -58,6 +58,8 @@ class PostgresManager(metaclass=SingletonMeta):
                 json_deserializer=json.loads,
                 pool_pre_ping=True,
                 pool_recycle=1800,
+                pool_size=10,
+                max_overflow=20,
             )
 
             # 创建异步会话工厂
@@ -258,13 +260,13 @@ class PostgresManager(metaclass=SingletonMeta):
 
     async def get_async_session(self) -> AsyncSession:
         """获取异步数据库会话"""
-        self._check_initialized()
+        self.initialize()  # 确保已初始化
         return self.AsyncSession()
 
     @asynccontextmanager
     async def get_async_session_context(self):
         """获取异步数据库会话的上下文管理器"""
-        self._check_initialized()
+        self.initialize()  # 确保已初始化
         session = self.AsyncSession()
         try:
             yield session

--- a/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
+++ b/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,6 +13,7 @@ from yuxi.agents.toolkits.buildin.install_skill import (
     ADMIN_ROLES,
     InstallSkillInput,
     _assert_admin,
+    _download_skill_dir,
     install_skill,
 )
 
@@ -19,9 +21,25 @@ from yuxi.agents.toolkits.buildin.install_skill import (
 _install_skill_func = install_skill.coroutine
 
 
+class AsyncSessionContext:
+    def __init__(self, session=None):
+        self.session = session or MagicMock()
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _mock_pg_session(mock_pg, session=None):
+    mock_pg.get_async_session_context.return_value = AsyncSessionContext(session)
+
+
 # =============================================================================
 # Tests for ADMIN_ROLES
 # =============================================================================
+
 
 def test_admin_roles_contains_admin():
     """ADMIN_ROLES should contain 'admin'."""
@@ -42,16 +60,17 @@ def test_admin_roles_is_set():
 # Tests for InstallSkillInput schema
 # =============================================================================
 
+
 def test_install_skill_input_source_field():
     """InstallSkillInput should have required 'source' field with proper description."""
     schema = InstallSkillInput.model_json_schema()
-    
+
     # source field should exist
     assert "source" in schema["properties"]
-    
+
     # source field should be required
     assert "source" in schema["required"]
-    
+
     # Check description contains sandbox and git format descriptions
     description = schema["properties"]["source"].get("description", "")
     assert "Sandbox" in description or "沙盒" in description
@@ -61,13 +80,13 @@ def test_install_skill_input_source_field():
 def test_install_skill_input_skill_names_field():
     """InstallSkillInput should have skill_names field that is nullable with default None."""
     schema = InstallSkillInput.model_json_schema()
-    
+
     # skill_names field should exist
     assert "skill_names" in schema["properties"]
-    
+
     # skill_names should NOT be required
     assert "skill_names" not in schema["required"]
-    
+
     # skill_names should be an array type
     skill_names_schema = schema["properties"]["skill_names"]
     assert skill_names_schema.get("type") == "array" or "anyOf" in skill_names_schema
@@ -88,12 +107,59 @@ def test_install_skill_input_with_skill_names():
     assert input_data.skill_names == ["skill1", "skill2"]
 
 
+def test_download_skill_dir_preserves_nested_files(tmp_path):
+    """_download_skill_dir should batch download files and preserve relative paths."""
+    calls = []
+
+    class Backend:
+        def ls_info(self, path):
+            if path.endswith("/demo"):
+                return [
+                    {"path": f"{path}/SKILL.md", "is_dir": False},
+                    {"path": f"{path}/scripts", "is_dir": True},
+                ]
+            return [{"path": f"{path}/run.py", "is_dir": False}]
+
+        def download_files(self, paths):
+            calls.append(paths)
+            return [
+                SimpleNamespace(path=path, content=f"content:{Path(path).name}".encode(), error=None) for path in paths
+            ]
+
+    _download_skill_dir(Backend(), "/home/gem/user-data/workspace/demo", tmp_path)
+
+    assert calls == [
+        [
+            "/home/gem/user-data/workspace/demo/SKILL.md",
+            "/home/gem/user-data/workspace/demo/scripts/run.py",
+        ]
+    ]
+    assert (tmp_path / "SKILL.md").read_bytes() == b"content:SKILL.md"
+    assert (tmp_path / "scripts" / "run.py").read_bytes() == b"content:run.py"
+
+
+def test_download_skill_dir_raises_on_download_error(tmp_path):
+    """_download_skill_dir should fail instead of importing a partial skill."""
+
+    class Backend:
+        def ls_info(self, path):
+            return [{"path": f"{path}/SKILL.md", "is_dir": False}]
+
+        def download_files(self, paths):
+            return [SimpleNamespace(path=paths[0], content=None, error="file_not_found")]
+
+    with pytest.raises(ValueError, match="下载沙盒文件失败"):
+        _download_skill_dir(Backend(), "/home/gem/user-data/workspace/demo", tmp_path)
+
+
 # =============================================================================
 # Tests for _assert_admin
 # =============================================================================
 
+
 class MockUser:
     """Mock user object for testing."""
+
     def __init__(self, role="user", user_id="test-user"):
         self.role = role
         self.user_id = user_id
@@ -104,15 +170,15 @@ async def test_assert_admin_missing_user_raises_error():
     """_assert_admin should raise ValueError when user does not exist."""
     mock_session = MagicMock()
     mock_user = None  # User not found
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
         mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
-        
+
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
             mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
-            
+
             with pytest.raises(ValueError, match="用户不存在"):
                 await _assert_admin(mock_session, "1")
 
@@ -122,15 +188,15 @@ async def test_assert_admin_non_admin_raises_error():
     """_assert_admin should raise ValueError when user is not an admin."""
     mock_session = MagicMock()
     mock_user = MockUser(role="user", user_id="test-user")
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
         mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
-        
+
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
             mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
-            
+
             with pytest.raises(ValueError, match="仅管理员可以安装 skill"):
                 await _assert_admin(mock_session, "1")
 
@@ -140,15 +206,15 @@ async def test_assert_admin_admin_passes():
     """_assert_admin should NOT raise for admin users."""
     mock_session = MagicMock()
     mock_user = MockUser(role="admin", user_id="test-admin-user")
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
         mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
-        
+
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
             mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
-            
+
             # Should not raise
             await _assert_admin(mock_session, "1")
 
@@ -158,15 +224,15 @@ async def test_assert_admin_superadmin_passes():
     """_assert_admin should NOT raise for superadmin users."""
     mock_session = MagicMock()
     mock_user = MockUser(role="superadmin", user_id="test-superadmin-user")
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
         mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
-        
+
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
             mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
-            
+
             # Should not raise
             await _assert_admin(mock_session, "1")
 
@@ -175,19 +241,20 @@ async def test_assert_admin_superadmin_passes():
 # Tests for install_skill function (使用 .func 访问底层函数)
 # =============================================================================
 
+
 @pytest.mark.asyncio
 async def test_install_skill_no_thread_id_returns_error():
     """install_skill should return error Command when thread_id is missing."""
     runtime = MagicMock()
     runtime.context.thread_id = None
     runtime.context.user_id = "test-user"
-    
+
     result = await _install_skill_func(
         source="/home/gem/user-data/workspace/test",
         runtime=runtime,
         tool_call_id="test-call-id",
     )
-    
+
     assert isinstance(result, Command)
     assert "messages" in result.update
 
@@ -198,13 +265,13 @@ async def test_install_skill_no_user_id_returns_error():
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = None
-    
+
     result = await _install_skill_func(
         source="/home/gem/user-data/workspace/test",
         runtime=runtime,
         tool_call_id="test-call-id",
     )
-    
+
     assert isinstance(result, Command)
     assert "messages" in result.update
 
@@ -215,13 +282,13 @@ async def test_install_skill_no_context_returns_error():
     runtime = MagicMock()
     runtime.context = SimpleNamespace()
     # No thread_id or user_id attributes
-    
+
     result = await _install_skill_func(
         source="/home/gem/user-data/workspace/test",
         runtime=runtime,
         tool_call_id="test-call-id",
     )
-    
+
     assert isinstance(result, Command)
     assert "messages" in result.update
 
@@ -230,21 +297,22 @@ async def test_install_skill_no_context_returns_error():
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_git_no_skill_names_returns_error(mock_pg):
     """install_skill should return error Command when using Git source without skill_names."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         # Mock _assert_admin to not raise (simulate admin user)
         mock_assert.return_value = None
-        
+
         result = await _install_skill_func(
             source="owner/repo",  # Git format, not starting with "/"
-            skill_names=None,    # Missing skill_names
+            skill_names=None,  # Missing skill_names
             runtime=runtime,
             tool_call_id="test-call-id",
         )
-    
+
     assert isinstance(result, Command)
     assert "messages" in result.update
     # Check that error mentions skill_names
@@ -256,31 +324,40 @@ async def test_install_skill_git_no_skill_names_returns_error(mock_pg):
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_git_with_skill_names_passes_admin_check(mock_pg):
     """install_skill with Git source and skill_names should pass admin check (but may fail other steps)."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
     runtime.context.skills = None
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         # Mock _assert_admin to not raise
         mock_assert.return_value = None
-        
-        with patch("yuxi.services.remote_skill_install_service.install_remote_skills_batch") as mock_install:
-            # Mock the git installation to return success
-            mock_install.return_value = [{"slug": "test-skill", "success": True}]
-            
-            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
-                # Mock enabling skill in config
-                mock_enable.return_value = True
-                
-                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = await _install_skill_func(
-                        source="owner/repo",
-                        skill_names=["test-skill"],
-                        runtime=runtime,
-                        tool_call_id="test-call-id",
-                    )
-    
+
+        preparation = SimpleNamespace(
+            results=[{"slug": "test-skill", "success": True, "source_dir": Path("/tmp/test-skill")}],
+            cleanup=MagicMock(),
+        )
+        with patch("yuxi.services.remote_skill_install_service.prepare_remote_skills_batch") as mock_prepare:
+            mock_prepare.return_value = preparation
+
+            with patch("yuxi.services.skill_service.import_skill_dir") as mock_import:
+                mock_import.return_value = SimpleNamespace(slug="test-skill")
+
+                with patch(
+                    "yuxi.agents.toolkits.buildin.install_skill._enable_skills_in_current_config"
+                ) as mock_enable:
+                    # Mock enabling skill in config
+                    mock_enable.return_value = True
+
+                    with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                        result = await _install_skill_func(
+                            source="owner/repo",
+                            skill_names=["test-skill"],
+                            runtime=runtime,
+                            tool_call_id="test-call-id",
+                        )
+
     assert isinstance(result, Command)
     result_data = result.update
     assert "messages" in result_data or "activated_skills" in result_data
@@ -290,27 +367,33 @@ async def test_install_skill_git_with_skill_names_passes_admin_check(mock_pg):
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_sandbox_success(mock_pg):
     """install_skill with valid sandbox path should work (full mock)."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
     runtime.context.skills = None
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         mock_assert.return_value = None
-        
-        with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
-            mock_install.return_value = ("my-skill", False)
-            
-            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
-                mock_enable.return_value = True
-                
-                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = await _install_skill_func(
-                        source="/home/gem/user-data/workspace/my-skill",
-                        runtime=runtime,
-                        tool_call_id="test-call-id",
-                    )
-    
+
+        with patch("yuxi.agents.toolkits.buildin.install_skill._prepare_skill_from_sandbox") as mock_prepare:
+            mock_prepare.return_value = (Path("/tmp/my-skill"), "my-skill")
+
+            with patch("yuxi.services.skill_service.import_skill_dir") as mock_import:
+                mock_import.return_value = SimpleNamespace(slug="my-skill")
+
+                with patch(
+                    "yuxi.agents.toolkits.buildin.install_skill._enable_skills_in_current_config"
+                ) as mock_enable:
+                    mock_enable.return_value = True
+
+                    with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                        result = await _install_skill_func(
+                            source="/home/gem/user-data/workspace/my-skill",
+                            runtime=runtime,
+                            tool_call_id="test-call-id",
+                        )
+
     assert isinstance(result, Command)
     assert "activated_skills" in result.update
     assert "my-skill" in result.update["activated_skills"]
@@ -320,20 +403,21 @@ async def test_install_skill_sandbox_success(mock_pg):
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_value_error_handling(mock_pg):
     """install_skill should handle ValueError from admin check gracefully."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         # Simulate admin check failure
         mock_assert.side_effect = ValueError("仅管理员可以安装 skill")
-        
+
         result = await _install_skill_func(
             source="/home/gem/user-data/workspace/test",
             runtime=runtime,
             tool_call_id="test-call-id",
         )
-    
+
     assert isinstance(result, Command)
     assert "messages" in result.update
     # Error message should contain the ValueError message
@@ -345,20 +429,21 @@ async def test_install_skill_value_error_handling(mock_pg):
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_exception_handling(mock_pg):
     """install_skill should handle unexpected exceptions gracefully."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         # Simulate unexpected exception
         mock_assert.side_effect = RuntimeError("Unexpected error")
-        
+
         result = await _install_skill_func(
             source="/home/gem/user-data/workspace/test",
             runtime=runtime,
             tool_call_id="test-call-id",
         )
-    
+
     assert isinstance(result, Command)
     assert "messages" in result.update
     # Error message should indicate an exception occurred
@@ -370,28 +455,34 @@ async def test_install_skill_exception_handling(mock_pg):
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_partial_config_failure(mock_pg):
     """install_skill should handle partial config persistence failure."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
     runtime.context.skills = None
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         mock_assert.return_value = None
-        
-        with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
-            mock_install.return_value = ("my-skill", False)
-            
-            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
-                # Simulate config persistence failure
-                mock_enable.return_value = False
-                
-                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = await _install_skill_func(
-                        source="/home/gem/user-data/workspace/my-skill",
-                        runtime=runtime,
-                        tool_call_id="test-call-id",
-                    )
-    
+
+        with patch("yuxi.agents.toolkits.buildin.install_skill._prepare_skill_from_sandbox") as mock_prepare:
+            mock_prepare.return_value = (Path("/tmp/my-skill"), "my-skill")
+
+            with patch("yuxi.services.skill_service.import_skill_dir") as mock_import:
+                mock_import.return_value = SimpleNamespace(slug="my-skill")
+
+                with patch(
+                    "yuxi.agents.toolkits.buildin.install_skill._enable_skills_in_current_config"
+                ) as mock_enable:
+                    # Simulate config persistence failure
+                    mock_enable.return_value = False
+
+                    with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                        result = await _install_skill_func(
+                            source="/home/gem/user-data/workspace/my-skill",
+                            runtime=runtime,
+                            tool_call_id="test-call-id",
+                        )
+
     assert isinstance(result, Command)
     result_str = str(result.update)
     # Should indicate config persistence issue
@@ -402,28 +493,34 @@ async def test_install_skill_partial_config_failure(mock_pg):
 @patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
 async def test_install_skill_slug_warning_for_renamed(mock_pg):
     """install_skill should include warning when skill is renamed."""
+    _mock_pg_session(mock_pg)
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = "test-user"
     runtime.context.skills = None
-    
+
     with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
         mock_assert.return_value = None
-        
-        with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
+
+        with patch("yuxi.agents.toolkits.buildin.install_skill._prepare_skill_from_sandbox") as mock_prepare:
             # Simulate skill being renamed during installation
-            mock_install.return_value = ("my-skill-v2", True)
-            
-            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
-                mock_enable.return_value = True
-                
-                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = await _install_skill_func(
-                        source="/home/gem/user-data/workspace/my-skill",
-                        runtime=runtime,
-                        tool_call_id="test-call-id",
-                    )
-    
+            mock_prepare.return_value = (Path("/tmp/my-skill"), "my-skill")
+
+            with patch("yuxi.services.skill_service.import_skill_dir") as mock_import:
+                mock_import.return_value = SimpleNamespace(slug="my-skill-v2")
+
+                with patch(
+                    "yuxi.agents.toolkits.buildin.install_skill._enable_skills_in_current_config"
+                ) as mock_enable:
+                    mock_enable.return_value = True
+
+                    with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                        result = await _install_skill_func(
+                            source="/home/gem/user-data/workspace/my-skill",
+                            runtime=runtime,
+                            tool_call_id="test-call-id",
+                        )
+
     assert isinstance(result, Command)
     result_str = str(result.update)
     # Should warn about slug rename

--- a/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
+++ b/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
@@ -1,0 +1,413 @@
+"""Tests for install_skill tool."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langgraph.types import Command
+
+from yuxi.agents.toolkits.buildin.install_skill import (
+    ADMIN_ROLES,
+    InstallSkillInput,
+    _assert_admin,
+    install_skill,
+)
+
+# 获取底层函数（@tool 装饰器包装为 StructuredTool 后不可直接调用）
+_install_skill_func = install_skill.func
+
+
+# =============================================================================
+# Tests for ADMIN_ROLES
+# =============================================================================
+
+def test_admin_roles_contains_admin():
+    """ADMIN_ROLES should contain 'admin'."""
+    assert "admin" in ADMIN_ROLES
+
+
+def test_admin_roles_contains_superadmin():
+    """ADMIN_ROLES should contain 'superadmin'."""
+    assert "superadmin" in ADMIN_ROLES
+
+
+def test_admin_roles_is_set():
+    """ADMIN_ROLES should be a set."""
+    assert isinstance(ADMIN_ROLES, set)
+
+
+# =============================================================================
+# Tests for InstallSkillInput schema
+# =============================================================================
+
+def test_install_skill_input_source_field():
+    """InstallSkillInput should have required 'source' field with proper description."""
+    schema = InstallSkillInput.model_json_schema()
+    
+    # source field should exist
+    assert "source" in schema["properties"]
+    
+    # source field should be required
+    assert "source" in schema["required"]
+    
+    # Check description contains sandbox and git format descriptions
+    description = schema["properties"]["source"].get("description", "")
+    assert "Sandbox" in description or "沙盒" in description
+    assert "Git" in description or "owner/repo" in description
+
+
+def test_install_skill_input_skill_names_field():
+    """InstallSkillInput should have skill_names field that is nullable with default None."""
+    schema = InstallSkillInput.model_json_schema()
+    
+    # skill_names field should exist
+    assert "skill_names" in schema["properties"]
+    
+    # skill_names should NOT be required
+    assert "skill_names" not in schema["required"]
+    
+    # skill_names should be an array type
+    skill_names_schema = schema["properties"]["skill_names"]
+    assert skill_names_schema.get("type") == "array" or "anyOf" in skill_names_schema
+
+
+def test_install_skill_input_default_values():
+    """InstallSkillInput should have correct default values."""
+    # Test with only required field
+    input_data = InstallSkillInput(source="/path/to/skill")
+    assert input_data.source == "/path/to/skill"
+    assert input_data.skill_names is None
+
+
+def test_install_skill_input_with_skill_names():
+    """InstallSkillInput should accept skill_names list."""
+    input_data = InstallSkillInput(source="owner/repo", skill_names=["skill1", "skill2"])
+    assert input_data.source == "owner/repo"
+    assert input_data.skill_names == ["skill1", "skill2"]
+
+
+# =============================================================================
+# Tests for _assert_admin
+# =============================================================================
+
+class MockUser:
+    """Mock user object for testing."""
+    def __init__(self, role="user", user_id="test-user"):
+        self.role = role
+        self.user_id = user_id
+
+
+@pytest.mark.asyncio
+async def test_assert_admin_missing_user_raises_error():
+    """_assert_admin should raise ValueError when user does not exist."""
+    mock_session = MagicMock()
+    mock_user = None  # User not found
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
+        mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo_cls.return_value = mock_repo
+            
+            with pytest.raises(ValueError, match="用户不存在"):
+                await _assert_admin("non-existent-user")
+
+
+@pytest.mark.asyncio
+async def test_assert_admin_non_admin_raises_error():
+    """_assert_admin should raise ValueError when user is not an admin."""
+    mock_session = MagicMock()
+    mock_user = MockUser(role="user", user_id="test-user")
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
+        mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo_cls.return_value = mock_repo
+            
+            with pytest.raises(ValueError, match="仅管理员可以安装 skill"):
+                await _assert_admin("test-user")
+
+
+@pytest.mark.asyncio
+async def test_assert_admin_admin_passes():
+    """_assert_admin should NOT raise for admin users."""
+    mock_session = MagicMock()
+    mock_user = MockUser(role="admin", user_id="test-admin-user")
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
+        mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo_cls.return_value = mock_repo
+            
+            # Should not raise
+            await _assert_admin("test-admin-user")
+
+
+@pytest.mark.asyncio
+async def test_assert_admin_superadmin_passes():
+    """_assert_admin should NOT raise for superadmin users."""
+    mock_session = MagicMock()
+    mock_user = MockUser(role="superadmin", user_id="test-superadmin-user")
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager") as mock_pg:
+        mock_pg.get_async_session_context.return_value.__aenter__.return_value = mock_session
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo_cls.return_value = mock_repo
+            
+            # Should not raise
+            await _assert_admin("test-superadmin-user")
+
+
+# =============================================================================
+# Tests for install_skill function (使用 .func 访问底层函数)
+# =============================================================================
+
+def test_install_skill_no_thread_id_returns_error():
+    """install_skill should return error Command when thread_id is missing."""
+    runtime = MagicMock()
+    runtime.context.thread_id = None
+    runtime.context.user_id = "test-user"
+    
+    result = _install_skill_func(
+        source="/home/gem/user-data/workspace/test",
+        runtime=runtime,
+        tool_call_id="test-call-id",
+    )
+    
+    assert isinstance(result, Command)
+    assert "messages" in result.update
+
+
+def test_install_skill_no_user_id_returns_error():
+    """install_skill should return error Command when user_id is missing."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = None
+    
+    result = _install_skill_func(
+        source="/home/gem/user-data/workspace/test",
+        runtime=runtime,
+        tool_call_id="test-call-id",
+    )
+    
+    assert isinstance(result, Command)
+    assert "messages" in result.update
+
+
+def test_install_skill_no_context_returns_error():
+    """install_skill should return error Command when runtime.context is missing attributes."""
+    runtime = MagicMock()
+    runtime.context = SimpleNamespace()
+    # No thread_id or user_id attributes
+    
+    result = _install_skill_func(
+        source="/home/gem/user-data/workspace/test",
+        runtime=runtime,
+        tool_call_id="test-call-id",
+    )
+    
+    assert isinstance(result, Command)
+    assert "messages" in result.update
+
+
+def test_install_skill_git_no_skill_names_returns_error():
+    """install_skill should return error Command when using Git source without skill_names."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        # Mock _assert_admin to not raise (simulate admin user)
+        mock_assert.return_value = None
+        
+        result = _install_skill_func(
+            source="owner/repo",  # Git format, not starting with "/"
+            skill_names=None,    # Missing skill_names
+            runtime=runtime,
+            tool_call_id="test-call-id",
+        )
+    
+    assert isinstance(result, Command)
+    assert "messages" in result.update
+    # Check that error mentions skill_names
+    error_content = str(result.update)
+    assert "skill_names" in error_content or "Git" in error_content
+
+
+def test_install_skill_git_with_skill_names_passes_admin_check():
+    """install_skill with Git source and skill_names should pass admin check (but may fail other steps)."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    runtime.context.skills = None
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        # Mock _assert_admin to not raise
+        mock_assert.return_value = None
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill._install_git_skills") as mock_install:
+            # Mock the git installation to return success
+            mock_install.return_value = [{"slug": "test-skill", "success": True}]
+            
+            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
+                # Mock enabling skill in config
+                mock_enable.return_value = True
+                
+                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                    result = _install_skill_func(
+                        source="owner/repo",
+                        skill_names=["test-skill"],
+                        runtime=runtime,
+                        tool_call_id="test-call-id",
+                    )
+    
+    assert isinstance(result, Command)
+    result_data = result.update
+    assert "messages" in result_data or "activated_skills" in result_data
+
+
+def test_install_skill_sandbox_success():
+    """install_skill with valid sandbox path should work (full mock)."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    runtime.context.skills = None
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        mock_assert.return_value = None
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
+            mock_install.return_value = "my-skill"
+            
+            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
+                mock_enable.return_value = True
+                
+                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                    result = _install_skill_func(
+                        source="/home/gem/user-data/workspace/my-skill",
+                        runtime=runtime,
+                        tool_call_id="test-call-id",
+                    )
+    
+    assert isinstance(result, Command)
+    assert "activated_skills" in result.update
+    assert "my-skill" in result.update["activated_skills"]
+
+
+def test_install_skill_value_error_handling():
+    """install_skill should handle ValueError from admin check gracefully."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        # Simulate admin check failure
+        mock_assert.side_effect = ValueError("仅管理员可以安装 skill")
+        
+        result = _install_skill_func(
+            source="/home/gem/user-data/workspace/test",
+            runtime=runtime,
+            tool_call_id="test-call-id",
+        )
+    
+    assert isinstance(result, Command)
+    assert "messages" in result.update
+    # Error message should contain the ValueError message
+    result_str = str(result.update)
+    assert "仅管理员可以安装 skill" in result_str
+
+
+def test_install_skill_exception_handling():
+    """install_skill should handle unexpected exceptions gracefully."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        # Simulate unexpected exception
+        mock_assert.side_effect = RuntimeError("Unexpected error")
+        
+        result = _install_skill_func(
+            source="/home/gem/user-data/workspace/test",
+            runtime=runtime,
+            tool_call_id="test-call-id",
+        )
+    
+    assert isinstance(result, Command)
+    assert "messages" in result.update
+    # Error message should indicate an exception occurred
+    result_str = str(result.update)
+    assert "安装异常" in result_str
+
+
+def test_install_skill_partial_config_failure():
+    """install_skill should handle partial config persistence failure."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    runtime.context.skills = None
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        mock_assert.return_value = None
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
+            mock_install.return_value = "my-skill"
+            
+            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
+                # Simulate config persistence failure
+                mock_enable.return_value = False
+                
+                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                    result = _install_skill_func(
+                        source="/home/gem/user-data/workspace/my-skill",
+                        runtime=runtime,
+                        tool_call_id="test-call-id",
+                    )
+    
+    assert isinstance(result, Command)
+    result_str = str(result.update)
+    # Should indicate config persistence issue
+    assert "持久化" in result_str or "Skill 已安装" in result_str
+
+
+def test_install_skill_slug_warning_for_renamed():
+    """install_skill should include warning when skill is renamed."""
+    runtime = MagicMock()
+    runtime.context.thread_id = "test-thread-id"
+    runtime.context.user_id = "test-user"
+    runtime.context.skills = None
+    
+    with patch("yuxi.agents.toolkits.buildin.install_skill._assert_admin") as mock_assert:
+        mock_assert.return_value = None
+        
+        with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
+            # Simulate skill being renamed during installation
+            mock_install.return_value = "my-skill-v2"
+            
+            with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
+                mock_enable.return_value = True
+                
+                with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
+                    result = _install_skill_func(
+                        source="/home/gem/user-data/workspace/my-skill",
+                        runtime=runtime,
+                        tool_call_id="test-call-id",
+                    )
+    
+    assert isinstance(result, Command)
+    result_str = str(result.update)
+    # Should warn about slug rename
+    assert "已安装为" in result_str or "⚠️" in result_str

--- a/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
+++ b/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
@@ -16,7 +16,7 @@ from yuxi.agents.toolkits.buildin.install_skill import (
 )
 
 # 获取底层函数（@tool 装饰器包装为 StructuredTool 后不可直接调用）
-_install_skill_func = install_skill.func
+_install_skill_func = install_skill.coroutine
 
 
 # =============================================================================
@@ -175,13 +175,14 @@ async def test_assert_admin_superadmin_passes():
 # Tests for install_skill function (使用 .func 访问底层函数)
 # =============================================================================
 
-def test_install_skill_no_thread_id_returns_error():
+@pytest.mark.asyncio
+async def test_install_skill_no_thread_id_returns_error():
     """install_skill should return error Command when thread_id is missing."""
     runtime = MagicMock()
     runtime.context.thread_id = None
     runtime.context.user_id = "test-user"
     
-    result = _install_skill_func(
+    result = await _install_skill_func(
         source="/home/gem/user-data/workspace/test",
         runtime=runtime,
         tool_call_id="test-call-id",
@@ -191,13 +192,14 @@ def test_install_skill_no_thread_id_returns_error():
     assert "messages" in result.update
 
 
-def test_install_skill_no_user_id_returns_error():
+@pytest.mark.asyncio
+async def test_install_skill_no_user_id_returns_error():
     """install_skill should return error Command when user_id is missing."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
     runtime.context.user_id = None
     
-    result = _install_skill_func(
+    result = await _install_skill_func(
         source="/home/gem/user-data/workspace/test",
         runtime=runtime,
         tool_call_id="test-call-id",
@@ -207,13 +209,14 @@ def test_install_skill_no_user_id_returns_error():
     assert "messages" in result.update
 
 
-def test_install_skill_no_context_returns_error():
+@pytest.mark.asyncio
+async def test_install_skill_no_context_returns_error():
     """install_skill should return error Command when runtime.context is missing attributes."""
     runtime = MagicMock()
     runtime.context = SimpleNamespace()
     # No thread_id or user_id attributes
     
-    result = _install_skill_func(
+    result = await _install_skill_func(
         source="/home/gem/user-data/workspace/test",
         runtime=runtime,
         tool_call_id="test-call-id",
@@ -223,7 +226,8 @@ def test_install_skill_no_context_returns_error():
     assert "messages" in result.update
 
 
-def test_install_skill_git_no_skill_names_returns_error():
+@pytest.mark.asyncio
+async def test_install_skill_git_no_skill_names_returns_error():
     """install_skill should return error Command when using Git source without skill_names."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -233,7 +237,7 @@ def test_install_skill_git_no_skill_names_returns_error():
         # Mock _assert_admin to not raise (simulate admin user)
         mock_assert.return_value = None
         
-        result = _install_skill_func(
+        result = await _install_skill_func(
             source="owner/repo",  # Git format, not starting with "/"
             skill_names=None,    # Missing skill_names
             runtime=runtime,
@@ -247,7 +251,8 @@ def test_install_skill_git_no_skill_names_returns_error():
     assert "skill_names" in error_content or "Git" in error_content
 
 
-def test_install_skill_git_with_skill_names_passes_admin_check():
+@pytest.mark.asyncio
+async def test_install_skill_git_with_skill_names_passes_admin_check():
     """install_skill with Git source and skill_names should pass admin check (but may fail other steps)."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -267,7 +272,7 @@ def test_install_skill_git_with_skill_names_passes_admin_check():
                 mock_enable.return_value = True
                 
                 with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = _install_skill_func(
+                    result = await _install_skill_func(
                         source="owner/repo",
                         skill_names=["test-skill"],
                         runtime=runtime,
@@ -279,7 +284,8 @@ def test_install_skill_git_with_skill_names_passes_admin_check():
     assert "messages" in result_data or "activated_skills" in result_data
 
 
-def test_install_skill_sandbox_success():
+@pytest.mark.asyncio
+async def test_install_skill_sandbox_success():
     """install_skill with valid sandbox path should work (full mock)."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -296,7 +302,7 @@ def test_install_skill_sandbox_success():
                 mock_enable.return_value = True
                 
                 with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = _install_skill_func(
+                    result = await _install_skill_func(
                         source="/home/gem/user-data/workspace/my-skill",
                         runtime=runtime,
                         tool_call_id="test-call-id",
@@ -307,7 +313,8 @@ def test_install_skill_sandbox_success():
     assert "my-skill" in result.update["activated_skills"]
 
 
-def test_install_skill_value_error_handling():
+@pytest.mark.asyncio
+async def test_install_skill_value_error_handling():
     """install_skill should handle ValueError from admin check gracefully."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -317,7 +324,7 @@ def test_install_skill_value_error_handling():
         # Simulate admin check failure
         mock_assert.side_effect = ValueError("仅管理员可以安装 skill")
         
-        result = _install_skill_func(
+        result = await _install_skill_func(
             source="/home/gem/user-data/workspace/test",
             runtime=runtime,
             tool_call_id="test-call-id",
@@ -330,7 +337,8 @@ def test_install_skill_value_error_handling():
     assert "仅管理员可以安装 skill" in result_str
 
 
-def test_install_skill_exception_handling():
+@pytest.mark.asyncio
+async def test_install_skill_exception_handling():
     """install_skill should handle unexpected exceptions gracefully."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -340,7 +348,7 @@ def test_install_skill_exception_handling():
         # Simulate unexpected exception
         mock_assert.side_effect = RuntimeError("Unexpected error")
         
-        result = _install_skill_func(
+        result = await _install_skill_func(
             source="/home/gem/user-data/workspace/test",
             runtime=runtime,
             tool_call_id="test-call-id",
@@ -353,7 +361,8 @@ def test_install_skill_exception_handling():
     assert "安装异常" in result_str
 
 
-def test_install_skill_partial_config_failure():
+@pytest.mark.asyncio
+async def test_install_skill_partial_config_failure():
     """install_skill should handle partial config persistence failure."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -371,7 +380,7 @@ def test_install_skill_partial_config_failure():
                 mock_enable.return_value = False
                 
                 with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = _install_skill_func(
+                    result = await _install_skill_func(
                         source="/home/gem/user-data/workspace/my-skill",
                         runtime=runtime,
                         tool_call_id="test-call-id",
@@ -383,7 +392,8 @@ def test_install_skill_partial_config_failure():
     assert "持久化" in result_str or "Skill 已安装" in result_str
 
 
-def test_install_skill_slug_warning_for_renamed():
+@pytest.mark.asyncio
+async def test_install_skill_slug_warning_for_renamed():
     """install_skill should include warning when skill is renamed."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -401,7 +411,7 @@ def test_install_skill_slug_warning_for_renamed():
                 mock_enable.return_value = True
                 
                 with patch("yuxi.services.skill_service.sync_thread_visible_skills"):
-                    result = _install_skill_func(
+                    result = await _install_skill_func(
                         source="/home/gem/user-data/workspace/my-skill",
                         runtime=runtime,
                         tool_call_id="test-call-id",

--- a/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
+++ b/backend/test/unit/agents/toolkits/buildin/test_install_skill.py
@@ -110,11 +110,11 @@ async def test_assert_admin_missing_user_raises_error():
         
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
-            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
             
             with pytest.raises(ValueError, match="用户不存在"):
-                await _assert_admin("non-existent-user")
+                await _assert_admin(mock_session, "1")
 
 
 @pytest.mark.asyncio
@@ -128,11 +128,11 @@ async def test_assert_admin_non_admin_raises_error():
         
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
-            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
             
             with pytest.raises(ValueError, match="仅管理员可以安装 skill"):
-                await _assert_admin("test-user")
+                await _assert_admin(mock_session, "1")
 
 
 @pytest.mark.asyncio
@@ -146,11 +146,11 @@ async def test_assert_admin_admin_passes():
         
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
-            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
             
             # Should not raise
-            await _assert_admin("test-admin-user")
+            await _assert_admin(mock_session, "1")
 
 
 @pytest.mark.asyncio
@@ -164,11 +164,11 @@ async def test_assert_admin_superadmin_passes():
         
         with patch("yuxi.agents.toolkits.buildin.install_skill.UserRepository") as mock_repo_cls:
             mock_repo = MagicMock()
-            mock_repo.get_by_user_id = AsyncMock(return_value=mock_user)
+            mock_repo.get_by_id_with_db = AsyncMock(return_value=mock_user)
             mock_repo_cls.return_value = mock_repo
             
             # Should not raise
-            await _assert_admin("test-superadmin-user")
+            await _assert_admin(mock_session, "1")
 
 
 # =============================================================================
@@ -227,7 +227,8 @@ async def test_install_skill_no_context_returns_error():
 
 
 @pytest.mark.asyncio
-async def test_install_skill_git_no_skill_names_returns_error():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_git_no_skill_names_returns_error(mock_pg):
     """install_skill should return error Command when using Git source without skill_names."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -252,7 +253,8 @@ async def test_install_skill_git_no_skill_names_returns_error():
 
 
 @pytest.mark.asyncio
-async def test_install_skill_git_with_skill_names_passes_admin_check():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_git_with_skill_names_passes_admin_check(mock_pg):
     """install_skill with Git source and skill_names should pass admin check (but may fail other steps)."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -263,7 +265,7 @@ async def test_install_skill_git_with_skill_names_passes_admin_check():
         # Mock _assert_admin to not raise
         mock_assert.return_value = None
         
-        with patch("yuxi.agents.toolkits.buildin.install_skill._install_git_skills") as mock_install:
+        with patch("yuxi.services.remote_skill_install_service.install_remote_skills_batch") as mock_install:
             # Mock the git installation to return success
             mock_install.return_value = [{"slug": "test-skill", "success": True}]
             
@@ -285,7 +287,8 @@ async def test_install_skill_git_with_skill_names_passes_admin_check():
 
 
 @pytest.mark.asyncio
-async def test_install_skill_sandbox_success():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_sandbox_success(mock_pg):
     """install_skill with valid sandbox path should work (full mock)."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -296,7 +299,7 @@ async def test_install_skill_sandbox_success():
         mock_assert.return_value = None
         
         with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
-            mock_install.return_value = "my-skill"
+            mock_install.return_value = ("my-skill", False)
             
             with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
                 mock_enable.return_value = True
@@ -314,7 +317,8 @@ async def test_install_skill_sandbox_success():
 
 
 @pytest.mark.asyncio
-async def test_install_skill_value_error_handling():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_value_error_handling(mock_pg):
     """install_skill should handle ValueError from admin check gracefully."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -338,7 +342,8 @@ async def test_install_skill_value_error_handling():
 
 
 @pytest.mark.asyncio
-async def test_install_skill_exception_handling():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_exception_handling(mock_pg):
     """install_skill should handle unexpected exceptions gracefully."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -362,7 +367,8 @@ async def test_install_skill_exception_handling():
 
 
 @pytest.mark.asyncio
-async def test_install_skill_partial_config_failure():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_partial_config_failure(mock_pg):
     """install_skill should handle partial config persistence failure."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -373,7 +379,7 @@ async def test_install_skill_partial_config_failure():
         mock_assert.return_value = None
         
         with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
-            mock_install.return_value = "my-skill"
+            mock_install.return_value = ("my-skill", False)
             
             with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
                 # Simulate config persistence failure
@@ -389,11 +395,12 @@ async def test_install_skill_partial_config_failure():
     assert isinstance(result, Command)
     result_str = str(result.update)
     # Should indicate config persistence issue
-    assert "持久化" in result_str or "Skill 已安装" in result_str
+    assert "当前会话配置中激活失败" in result_str or "技能已安装到系统" in result_str
 
 
 @pytest.mark.asyncio
-async def test_install_skill_slug_warning_for_renamed():
+@patch("yuxi.agents.toolkits.buildin.install_skill.pg_manager")
+async def test_install_skill_slug_warning_for_renamed(mock_pg):
     """install_skill should include warning when skill is renamed."""
     runtime = MagicMock()
     runtime.context.thread_id = "test-thread-id"
@@ -405,7 +412,7 @@ async def test_install_skill_slug_warning_for_renamed():
         
         with patch("yuxi.agents.toolkits.buildin.install_skill._install_skill_from_sandbox") as mock_install:
             # Simulate skill being renamed during installation
-            mock_install.return_value = "my-skill-v2"
+            mock_install.return_value = ("my-skill-v2", True)
             
             with patch("yuxi.agents.toolkits.buildin.install_skill._enable_skill_in_current_config") as mock_enable:
                 mock_enable.return_value = True

--- a/backend/test/unit/repositories/test_agent_config_repository.py
+++ b/backend/test/unit/repositories/test_agent_config_repository.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from yuxi.repositories.agent_config_repository import AgentConfigRepository, _merge_skill_slugs
+
+
+class FakeScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+
+class FakeDb:
+    def __init__(self, config):
+        self.config = config
+        self.statements = []
+        self.commit = AsyncMock()
+        self.refresh = AsyncMock()
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return FakeScalarResult(self.config)
+
+
+def test_merge_skill_slugs_preserves_order_and_dedupes():
+    assert _merge_skill_slugs(["old", "new", "old", "", None], ["new", "third"]) == [
+        "old",
+        "new",
+        "third",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_for_update_uses_row_lock():
+    config = SimpleNamespace(config_json={}, updated_at=None)
+    db = FakeDb(config)
+    repo = AgentConfigRepository(db)
+
+    result = await repo._get_by_id_for_update(1)
+
+    assert result is config
+    compiled_sql = str(db.statements[0].compile(dialect=postgresql.dialect()))
+    assert "FOR UPDATE" in compiled_sql
+
+
+@pytest.mark.asyncio
+async def test_add_skills_to_config_json_writes_context_skills_without_duplicates():
+    config = SimpleNamespace(config_json={"context": {"skills": ["existing", "new"]}}, updated_at=None)
+    db = FakeDb(config)
+    repo = AgentConfigRepository(db)
+
+    result = await repo.add_skills_to_config_json(agent_config_id=1, new_slugs=["new", "extra"])
+
+    assert result is True
+    assert config.config_json == {"context": {"skills": ["existing", "new", "extra"]}}
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once_with(config)
+
+
+@pytest.mark.asyncio
+async def test_add_skills_to_config_json_creates_missing_context():
+    config = SimpleNamespace(config_json={}, updated_at=None)
+    db = FakeDb(config)
+    repo = AgentConfigRepository(db)
+
+    result = await repo.add_skills_to_config_json(agent_config_id=1, new_slugs=["demo-skill"])
+
+    assert result is True
+    assert config.config_json == {"context": {"skills": ["demo-skill"]}}
+
+
+@pytest.mark.asyncio
+async def test_add_skills_to_config_json_returns_false_when_missing_config():
+    db = FakeDb(None)
+    repo = AgentConfigRepository(db)
+
+    result = await repo.add_skills_to_config_json(agent_config_id=404, new_slugs=["demo-skill"])
+
+    assert result is False
+    db.commit.assert_not_awaited()
+    db.refresh.assert_not_awaited()


### PR DESCRIPTION
## 变更描述
支持在 Agent 对话中通过 `install_skill` 工具安装 Skill，管理员可从 Sandbox 路径或 Git 仓库安装并自动激活。
## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 其他
## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作
**相关日志或者截图**
参数: { "skill_names": null, "source": "/home/gem/user-data/outputs/tmp/react-best-practices/react-best-practices" }
✅ 成功安装并激活技能: vercel-react-best-practices
## 说明
该 PR 包含 2 个 commit：
| Commit | 内容 |
|--------|------|
| `db861da4` | feat(skill): 新增 Agent 会话中安装 Skill 功能 |
| `013d1886` | fix(skill): 修复 install_skill 同步异步混用及数据库连接问题 |
### 主要变更
- **新增 `install_skill` 工具**：支持 Sandbox 路径和 Git 仓库安装，安装后自动激活到当前会话
- **修复同步/异步混用**：`asyncio.run()` 在已有事件循环中崩溃 → 改为 `async def`
- **修复数据库问题**：表名 `agent_config` → `agent_configs`、jsonb 类型转换、连接池配置
- **修复 `[dict]*n` 引用共享 bug**：改为列表推导式
- **修复 slug warning 误报**：改为解析 SKILL.md name 与最终 slug 对比，而非比较目录名
- **UserRepository**：新增 `*_with_db` 方法，支持复用外部 db 会话
- **新增测试**：423 行 + 165 行单元测试
---
💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范