### PR TITLE
解决embed.py整合阿里云百炼不同向量模型时请求参数问题，同时添加阿里云百炼模型配置

### DIFF
--- a/backend/package/yuxi/config/builtin_providers.py
+++ b/backend/package/yuxi/config/builtin_providers.py
@@ -49,6 +49,26 @@ BUILTIN_PROVIDERS: list[dict[str, Any]] = [
         "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
         "api_key_env": "DASHSCOPE_API_KEY",
         "models_endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1/models",
+        "embedding_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings",
+        "capabilities": ["chat", "embedding"],
+        "enabled_models": [
+            {"id": "qwen3-plus", "type": "chat", "display_name": "Qwen3 Plus"},
+            {"id": "qwen3-max", "type": "chat", "display_name": "Qwen3 Max"},
+            {"id": "deepseek-v4-flash", "type": "chat", "display_name": "DeepSeek V4 Flash"},
+            {"id": "deepseek-v4-pro", "type": "chat", "display_name": "DeepSeek V4 Pro"},
+            {"id": "text-embedding-v4", "type": "embedding", "display_name": "Text Embedding V4", "dimension": 1024, "batch_size": 10},
+        ],
+    },
+    {
+        "provider_id": "dashscope",
+        "display_name": "DashScope Rerank",
+        "base_url": "https://dashscope.aliyuncs.com/api/v1/services/rerank",
+        "api_key_env": "DASHSCOPE_API_KEY",
+        "rerank_base_url": "https://dashscope.aliyuncs.com/api/v1/services/rerank",
+        "capabilities": ["rerank"],
+        "enabled_models": [
+            {"id": "qwen3-rerank", "type": "rerank", "display_name": "Qwen3 Rerank"},
+        ],
     },
     {
         "provider_id": "alibaba-coding-plan-cn",

--- a/backend/package/yuxi/models/embed.py
+++ b/backend/package/yuxi/models/embed.py
@@ -85,6 +85,7 @@ class BaseEmbeddingModel(ABC):
         batch_size = batch_size or self.batch_size
         data = []
         task_id = None
+        logger.info(f"[INFO] Embedding abatch_encode: msg_len={len(messages)}, batch_size={batch_size}")
         if len(messages) > batch_size:
             task_id = hashstr(messages)
             self.embed_state[task_id] = {"status": "in-progress", "total": len(messages), "progress": 0}
@@ -187,9 +188,16 @@ class OtherEmbedding(BaseEmbeddingModel):
         self.headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
 
     def build_payload(self, message: list[str] | str) -> dict:
-        return {"model": self.model, "input": message}
+        payload = {"model": self.model, "input": message}
+        if self.dimension:
+            payload["dimensions"] = self.dimension
+        if self.batch_size:
+            payload["batch_size"] = self.batch_size
+        return payload
 
     def encode(self, message: list[str] | str) -> list[list[float]]:
+        if isinstance(message, list) and len(message) > self.batch_size:
+            return self.batch_encode(message, batch_size=self.batch_size)
         payload = self.build_payload(message)
         try:
             response = requests.post(self.base_url, json=payload, headers=self.headers, timeout=60)
@@ -203,6 +211,8 @@ class OtherEmbedding(BaseEmbeddingModel):
             raise ValueError(f"Other Embedding request failed: {e}")
 
     async def aencode(self, message: list[str] | str) -> list[list[float]]:
+        if isinstance(message, list) and len(message) > self.batch_size:
+            return await self.abatch_encode(message, batch_size=self.batch_size)
         payload = self.build_payload(message)
         async with httpx.AsyncClient() as client:
             try:
@@ -214,7 +224,8 @@ class OtherEmbedding(BaseEmbeddingModel):
                 return [item["embedding"] for item in result["data"]]
             except (httpx.RequestError, json.JSONDecodeError) as e:
                 raise ValueError(f"Other Embedding async request failed: {e}, {payload}, {self.base_url=}")
-
+            except httpx.HTTPStatusError as e:
+                raise ValueError(f"Other Embedding async request failed: {e}, {payload}, {self.base_url=}")
 
 async def test_embedding_model_status(model_id: str) -> dict:
     """


### PR DESCRIPTION
## 变更描述
解决embed.py整合阿里云百炼不同向量模型时请求参数问题，同时添加阿里云百炼模型配置

## 变更类型
- [ ] Bug 修复

## 测试
- [ ] 已在 Docker 环境测试
- [ ] 相关功能正常工作

**相关日志或者截图**
<img width="1131" height="483" alt="image" src="https://github.com/user-attachments/assets/be66a28e-fbd4-4cf5-8389-99d0e62b53c1" />
<img width="516" height="648" alt="image" src="https://github.com/user-attachments/assets/0e5f4f56-ed3d-4bf2-9e03-e669e3872120" />


## 说明
无

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范