### PR TITLE
fix(knowledge): 在 LITE_MODE 下安全跳过不支持的知识库类型，防止 API 崩溃

### DIFF
--- a/backend/package/yuxi/knowledge/manager.py
+++ b/backend/package/yuxi/knowledge/manager.py
@@ -62,6 +62,9 @@ class KnowledgeBaseManager:
 
             # 为每种使用中的知识库类型创建实例并加载元数据
             for kb_type in kb_types_in_use:
+                if not KnowledgeBaseFactory.is_type_supported(kb_type):
+                    logger.warning(f"[InitializeKB] Skip initialization for unsupported knowledge base type: {kb_type}")
+                    continue
                 try:
                     kb_instance = self._get_or_create_kb_instance(kb_type)
                     # 让 KB 实例自行加载元数据
@@ -180,6 +183,9 @@ class KnowledgeBaseManager:
         metadata_reloaded_types: set[str] = set()
         for row in rows:
             kb_type = row.kb_type or "lightrag"
+            if not KnowledgeBaseFactory.is_type_supported(kb_type):
+                logger.warning(f"Skip database {row.db_id} due to unsupported knowledge base type: {kb_type}")
+                continue
             kb_instance = self._get_or_create_kb_instance(kb_type)
             db_info = kb_instance.get_database_info(row.db_id, include_files=False)
             if not db_info and kb_type not in metadata_reloaded_types:


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么

- 检查并跳过未注册/不支持的 kb_type，避免抛出 KBNotFoundError 导致接口 500
- 分别在初始化 (_initialize_existing_kbs) 和概览列表查询 (get_databases) 中增加 checks

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [ ] 相关功能正常工作

**相关日志或者截图**
<img width="945" height="764" alt="image" src="https://github.com/user-attachments/assets/a7f31a1e-7016-4c39-9bb2-90dd2f5ca4f9" />
- 一开始会报错，改完后就可以问答了

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范