### PR TITLE
fix: 修复 sandbox backend edit 方法错误访问 result.data.success

### DIFF
--- a/backend/package/yuxi/agents/backends/sandbox/backend.py
+++ b/backend/package/yuxi/agents/backends/sandbox/backend.py
@@ -293,8 +293,8 @@ class ProvisionerSandboxBackend(BaseSandbox):
                 new_str=new_string,
                 replace_mode=replace_mode,
             )
-            if not result.data.success:
-                return EditResult(error=result.data.message or f"Error editing file '{file_path}'")
+            if not result.success:
+                return EditResult(error=result.message or f"Error editing file '{file_path}'")
         except Exception as exc:  # noqa: BLE001
             return EditResult(error=f"Error editing file: {exc}")
 


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么
- str_replace_editor() 返回的 result 已经是 ResponseStrReplaceEditorResult， .success 和 .message 在顶层属性上，不应再经过 .data 访问。 此错误导致编辑文件时报 'StrReplaceEditorResult' object has no attribute 'success'。

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

<img width="1403" height="851" alt="image" src="https://github.com/user-attachments/assets/6625050f-f237-4887-b8e3-55bf6f546940" />


## 说明
（可选）有什么需要特别说明的吗？
#717 
---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范