### PR TITLE
Feat：新增支持undo/fork 功能

### DIFF
--- a/backend/package/yuxi/repositories/checkpoint_repository.py
+++ b/backend/package/yuxi/repositories/checkpoint_repository.py
@@ -1,0 +1,75 @@
+"""Checkpoint 查询 Repository
+
+基于 checkpoint_tables 表定义构建具体查询（CTE / select），
+供 undo / fork 服务层调用。
+"""
+
+from sqlalchemy import select
+
+from yuxi.storage.postgres.checkpoint_tables import checkpoints
+
+
+def build_descendants_cte(thread_id: str, start_checkpoint_id: str):
+    """递归向下查找所有后代 checkpoint（undo 用）。"""
+    ckpt = checkpoints
+
+    base = (
+        select(ckpt.c.checkpoint_id)
+        .where(ckpt.c.thread_id == thread_id, ckpt.c.checkpoint_id == start_checkpoint_id)
+        .cte(name="descendants", recursive=True)
+    )
+
+    recursive_part = (
+        select(ckpt.c.checkpoint_id)
+        .select_from(ckpt.join(base, ckpt.c.parent_checkpoint_id == base.c.checkpoint_id))
+        .where(ckpt.c.thread_id == thread_id)
+    )
+
+    return base.union_all(recursive_part)
+
+
+def build_ancestors_cte(thread_id: str, start_checkpoint_id: str):
+    """递归向上查找所有祖先 checkpoint（fork 用）。"""
+    ckpt = checkpoints
+
+    base = (
+        select(ckpt.c.checkpoint_id, ckpt.c.parent_checkpoint_id)
+        .where(ckpt.c.thread_id == thread_id, ckpt.c.checkpoint_id == start_checkpoint_id)
+        .cte(name="ancestors", recursive=True)
+    )
+
+    recursive_part = (
+        select(ckpt.c.checkpoint_id, ckpt.c.parent_checkpoint_id)
+        .select_from(ckpt.join(base, ckpt.c.checkpoint_id == base.c.parent_checkpoint_id))
+        .where(ckpt.c.thread_id == thread_id)
+    )
+
+    return base.union_all(recursive_part)
+
+
+def select_checkpoint_entry(thread_id: str, request_id: str):
+    """查找 source='input' 的 checkpoint 入口记录。"""
+    ckpt = checkpoints
+    return (
+        select(ckpt.c.checkpoint_id)
+        .where(
+            ckpt.c.thread_id == thread_id,
+            ckpt.c.metadata["request_id"].astext == request_id,
+            ckpt.c.metadata["source"].astext == "input",
+        )
+        .limit(1)
+    )
+
+
+def select_checkpoint_parent(thread_id: str, request_id: str):
+    """查找 source='input' 的 checkpoint 的 parent_checkpoint_id（fork 回档点）。"""
+    ckpt = checkpoints
+    return (
+        select(ckpt.c.parent_checkpoint_id)
+        .where(
+            ckpt.c.thread_id == thread_id,
+            ckpt.c.metadata["request_id"].astext == request_id,
+            ckpt.c.metadata["source"].astext == "input",
+        )
+        .limit(1)
+    )

--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -500,6 +500,10 @@ async def get_thread_history_view(
     role_type_map = {"user": "human", "assistant": "ai", "tool": "tool", "system": "system"}
 
     for msg in messages:
+        # 跳过已被 Undo 逻辑删除的消息
+        if (msg.extra_metadata or {}).get("is_deleted") == "true":
+            continue
+
         user_feedback = None
         if msg.feedbacks:
             for feedback in msg.feedbacks:

--- a/backend/package/yuxi/services/thread_fork_service.py
+++ b/backend/package/yuxi/services/thread_fork_service.py
@@ -1,0 +1,321 @@
+"""会话分叉 (Fork) 服务 —— 克隆 checkpoint 状态 + 复制业务消息到新会话
+
+全部使用 SQLAlchemy ORM / expression language，无 text() 裸 SQL。
+"""
+
+import uuid as uuid_lib
+
+from sqlalchemy import insert as sa_insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from yuxi.repositories.checkpoint_repository import (
+    build_ancestors_cte,
+    select_checkpoint_parent,
+)
+from yuxi.repositories.conversation_repository import ConversationRepository
+from yuxi.storage.postgres.checkpoint_tables import (
+    checkpoint_blobs,
+    checkpoints,
+    checkpoint_writes,
+)
+from yuxi.storage.postgres.models_business import (
+    Conversation,
+    ConversationStats,
+    Message,
+    MessageFeedback,
+    ToolCall,
+)
+from yuxi.utils.datetime_utils import utc_now_naive
+from yuxi.utils.logging_config import logger
+
+
+class ForkValidationError(Exception):
+    """Fork 请求参数无效"""
+
+
+async def _get_message(db: AsyncSession, message_id: int) -> Message | None:
+    result = await db.execute(select(Message).where(Message.id == message_id))
+    return result.scalar_one_or_none()
+
+
+async def _clone_physical_files(thread_id_a: str, thread_id_b: str) -> None:
+    """Phase 1: 克隆物理文件（Sandbox + MinIO）。
+
+    当前为占位实现，等待 Sandbox Provisioner / MinIO 集成。
+    """
+    logger.info("Physical file clone skipped (not yet implemented): %s -> %s", thread_id_a, thread_id_b)
+
+
+async def _cleanup_cloned_files(thread_id_b: str) -> None:
+    """Best-effort 清理克隆失败后的残留物理文件。"""
+    logger.info("Physical file cleanup skipped (not yet implemented): %s", thread_id_b)
+
+
+async def fork_thread(
+    db: AsyncSession,
+    thread_id_a: str,
+    message_id: int,
+    title: str | None,
+    user_id: str,
+) -> dict:
+    """执行 Fork 操作：从原会话指定消息处分叉出新会话。
+
+    流程：Phase 1 物理文件克隆 → Phase 2 数据库事务克隆。
+    """
+    conv_repo = ConversationRepository(db)
+    thread_id_b = str(uuid_lib.uuid4())
+
+    # ---- Phase 1: 物理资源克隆 ----
+    try:
+        await _clone_physical_files(thread_id_a, thread_id_b)
+    except Exception as e:
+        raise ForkValidationError(f"文件克隆失败: {e}")
+
+    # ---- 校验原会话 ----
+    conversation_a = await conv_repo.get_conversation_by_thread_id(thread_id_a)
+    if not conversation_a or conversation_a.user_id != str(user_id) or conversation_a.status == "deleted":
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("对话线程不存在")
+    conv_id_a = conversation_a.id
+
+    # ---- 加锁原会话 ----
+    await db.execute(
+        select(Conversation.id).where(Conversation.thread_id == thread_id_a).with_for_update()
+    )
+
+    # ---- 定位目标消息与 request_id ----
+    target_msg = await _get_message(db, message_id)
+    if not target_msg or target_msg.conversation_id != conv_id_a:
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("消息不存在或不属于该会话")
+
+    if target_msg.role == "assistant":
+        user_msgs = await db.execute(
+            select(Message)
+            .where(Message.conversation_id == conv_id_a, Message.role == "user", Message.id <= message_id)
+            .order_by(Message.id.desc())
+            .limit(1),
+        )
+        target_msg = user_msgs.scalar_one_or_none()
+        if not target_msg:
+            await _cleanup_cloned_files(thread_id_b)
+            raise ForkValidationError("未找到对应的用户消息")
+        message_id = target_msg.id
+
+    target_request_id = (target_msg.extra_metadata or {}).get("request_id")
+    if not target_request_id:
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("目标消息缺少 request_id，无法定位 checkpoint")
+
+    # ---- 定位分叉回档起点 ----
+    entry_result = await db.execute(select_checkpoint_parent(thread_id_a, target_request_id))
+    entry_row = entry_result.fetchone()
+    if not entry_row or not entry_row[0]:
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("该消息之前没有可用的 AI 推理状态")
+    target_checkpoint_id = entry_row[0]
+
+    # ---- 递归 CTE 向上查找所有祖先 checkpoint ----
+    ancestors_cte = build_ancestors_cte(thread_id_a, target_checkpoint_id)
+    ancestors_result = await db.execute(select(ancestors_cte.c.checkpoint_id))
+    ancestor_ids = [row[0] for row in ancestors_result.fetchall()]
+    cloned_checkpoint_count = len(ancestor_ids)
+
+    # ---- Phase 2: 数据库事务级克隆 ----
+    try:
+        # 1. 创建新会话
+        fork_title = title or f"{conversation_a.title or '未命名'}_分叉"
+        new_conversation = Conversation(
+            thread_id=thread_id_b,
+            user_id=str(user_id),
+            agent_id=conversation_a.agent_id,
+            title=fork_title,
+            status="active",
+            extra_metadata=dict(conversation_a.extra_metadata or {}),
+        )
+        db.add(new_conversation)
+        await db.flush()
+        conv_id_b = new_conversation.id
+
+        # 2. 克隆 checkpoints —— INSERT ... SELECT via from_select()
+        ckpt_cols = [
+            "thread_id", "checkpoint_ns", "checkpoint_id",
+            "parent_checkpoint_id", "type", "checkpoint", "metadata",
+        ]
+        await db.execute(
+            sa_insert(checkpoints).from_select(
+                ckpt_cols,
+                select(
+                    *[checkpoints.c[col] for col in ckpt_cols]
+                ).where(
+                    checkpoints.c.thread_id == thread_id_a,
+                    checkpoints.c.checkpoint_id.in_(ancestor_ids),
+                ),
+            )
+        )
+
+        # 3. 克隆 checkpoint_writes
+        cw_cols = [
+            "thread_id", "checkpoint_ns", "checkpoint_id",
+            "task_id", "idx", "channel", "type", "blob", "task_path",
+        ]
+        await db.execute(
+            sa_insert(checkpoint_writes).from_select(
+                cw_cols,
+                select(
+                    *[checkpoint_writes.c[col] for col in cw_cols]
+                ).where(
+                    checkpoint_writes.c.thread_id == thread_id_a,
+                    checkpoint_writes.c.checkpoint_id.in_(ancestor_ids),
+                ),
+            )
+        )
+
+        # 4. 克隆 checkpoint_blobs —— 从祖先 checkpoint 提取 (channel, version)，去重后克隆
+        ancestor_ckpts_result = await db.execute(
+            select(checkpoints.c.checkpoint).where(
+                checkpoints.c.thread_id == thread_id_a,
+                checkpoints.c.checkpoint_id.in_(ancestor_ids),
+            )
+        )
+        blob_pairs: set[tuple[str, str]] = set()
+        for (ckpt_json,) in ancestor_ckpts_result.fetchall():
+            channel_versions = (ckpt_json or {}).get("channel_versions", {}) or {}
+            for ch, ver in channel_versions.items():
+                blob_pairs.add((ch, ver))
+
+        if blob_pairs:
+            # 查询原 thread 下匹配的 blobs
+            conditions = []
+            for ch, ver in blob_pairs:
+                conditions.append((checkpoint_blobs.c.channel == ch) & (checkpoint_blobs.c.version == ver))
+            blob_rows_result = await db.execute(
+                select(checkpoint_blobs).where(
+                    checkpoint_blobs.c.thread_id == thread_id_a,
+                    conditions[0] if len(conditions) == 1 else None,
+                )
+            )
+            # 对多种 pair 的情况，逐对查询
+            if len(blob_pairs) > 1:
+                all_rows = []
+                for ch, ver in blob_pairs:
+                    pair_result = await db.execute(
+                        select(checkpoint_blobs).where(
+                            checkpoint_blobs.c.thread_id == thread_id_a,
+                            checkpoint_blobs.c.channel == ch,
+                            checkpoint_blobs.c.version == ver,
+                        )
+                    )
+                    all_rows.extend(pair_result.fetchall())
+            else:
+                all_rows = blob_rows_result.fetchall()
+
+            # 插入新 thread_id
+            for row in all_rows:
+                await db.execute(
+                    sa_insert(checkpoint_blobs).values(
+                        thread_id=thread_id_b,
+                        checkpoint_ns=row.checkpoint_ns,
+                        channel=row.channel,
+                        version=row.version,
+                        type=row.type,
+                        blob=row.blob,
+                    )
+                )
+
+        # 5. 查询源消息（Python 侧过滤已删除）
+        src_messages_result = await db.execute(
+            select(Message)
+            .where(Message.conversation_id == conv_id_a, Message.id <= message_id)
+            .order_by(Message.id.asc()),
+        )
+        src_messages = [
+            m for m in src_messages_result.scalars().all()
+            if (m.extra_metadata or {}).get("is_deleted") != "true"
+        ]
+
+        # 6. 逐条克隆消息，建立 old_id → new_id 映射
+        id_map: dict[int, int] = {}
+        for msg in src_messages:
+            new_msg = Message(
+                conversation_id=conv_id_b,
+                role=msg.role,
+                content=msg.content,
+                message_type=msg.message_type,
+                image_content=msg.image_content,
+                extra_metadata=dict(msg.extra_metadata or {}),
+                token_count=msg.token_count,
+                created_at=msg.created_at,
+            )
+            db.add(new_msg)
+            await db.flush()
+            id_map[msg.id] = new_msg.id
+
+        # 7. 克隆 tool_calls
+        if src_messages:
+            old_ids = list(id_map.keys())
+            src_tool_calls_result = await db.execute(
+                select(ToolCall).where(ToolCall.message_id.in_(old_ids))
+            )
+            for tc in src_tool_calls_result.scalars().all():
+                db.add(ToolCall(
+                    message_id=id_map[tc.message_id],
+                    tool_name=tc.tool_name,
+                    tool_input=tc.tool_input,
+                    tool_output=tc.tool_output,
+                    status=tc.status,
+                    error_message=tc.error_message,
+                    langgraph_tool_call_id=tc.langgraph_tool_call_id,
+                    created_at=tc.created_at,
+                ))
+
+        # 8. 克隆 message_feedbacks
+        if src_messages:
+            src_feedbacks_result = await db.execute(
+                select(MessageFeedback).where(MessageFeedback.message_id.in_(old_ids))
+            )
+            for fb in src_feedbacks_result.scalars().all():
+                db.add(MessageFeedback(
+                    message_id=id_map[fb.message_id],
+                    user_id=fb.user_id,
+                    rating=fb.rating,
+                    reason=fb.reason,
+                    created_at=fb.created_at,
+                ))
+
+        # 9. 计算克隆统计（Python 侧）
+        cloned_msg_count = len(src_messages)
+        cloned_token_count = sum(m.token_count or 0 for m in src_messages)
+
+        # 10. 初始化新会话统计
+        stats_a_result = await db.execute(
+            select(ConversationStats).where(ConversationStats.conversation_id == conv_id_a)
+        )
+        stats_a = stats_a_result.scalar_one_or_none()
+
+        db.add(ConversationStats(
+            conversation_id=conv_id_b,
+            message_count=cloned_msg_count,
+            total_tokens=cloned_token_count,
+            model_used=stats_a.model_used if stats_a else None,
+            created_at=utc_now_naive(),
+            updated_at=utc_now_naive(),
+        ))
+
+        await db.flush()
+
+        logger.info(
+            "Fork thread %s -> %s, cloned %d messages, %d checkpoints",
+            thread_id_a, thread_id_b, cloned_msg_count, cloned_checkpoint_count,
+        )
+
+        return {
+            "message": "分叉成功",
+            "new_thread_id": thread_id_b,
+            "cloned_message_count": cloned_msg_count,
+            "cloned_checkpoint_count": cloned_checkpoint_count,
+        }
+
+    except Exception:
+        await _cleanup_cloned_files(thread_id_b)
+        raise

--- a/backend/package/yuxi/services/thread_fork_service.py
+++ b/backend/package/yuxi/services/thread_fork_service.py
@@ -5,12 +5,12 @@
 
 import uuid as uuid_lib
 
-from sqlalchemy import insert as sa_insert, select
+from sqlalchemy import func as sa_func, insert as sa_insert, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from yuxi.repositories.checkpoint_repository import (
     build_ancestors_cte,
-    select_checkpoint_parent,
+    select_checkpoint_entry,
 )
 from yuxi.repositories.conversation_repository import ConversationRepository
 from yuxi.storage.postgres.checkpoint_tables import (
@@ -78,6 +78,14 @@ async def fork_thread(
         raise ForkValidationError("对话线程不存在")
     conv_id_a = conversation_a.id
 
+    # ---- 检查是否存在 checkpoint（旧会话可能没有） ----
+    ckpt_count_result = await db.execute(
+        select(sa_func.count()).select_from(checkpoints).where(checkpoints.c.thread_id == thread_id_a)
+    )
+    if ckpt_count_result.scalar() == 0:
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("此对话没有保存 AI 推理记录，无法分叉（可能是较早创建的会话）")
+
     # ---- 加锁原会话 ----
     await db.execute(
         select(Conversation.id).where(Conversation.thread_id == thread_id_a).with_for_update()
@@ -89,31 +97,87 @@ async def fork_thread(
         await _cleanup_cloned_files(thread_id_b)
         raise ForkValidationError("消息不存在或不属于该会话")
 
-    if target_msg.role == "assistant":
-        user_msgs = await db.execute(
-            select(Message)
-            .where(Message.conversation_id == conv_id_a, Message.role == "user", Message.id <= message_id)
-            .order_by(Message.id.desc())
-            .limit(1),
-        )
-        target_msg = user_msgs.scalar_one_or_none()
-        if not target_msg:
-            await _cleanup_cloned_files(thread_id_b)
-            raise ForkValidationError("未找到对应的用户消息")
-        message_id = target_msg.id
+    # ---- 计算克隆边界 ----
+    # 核心语义：用户在哪 fork，就 fork 哪里（含）之前的全部内容
+    # 前端 fork 按钮只在 assistant 消息上，传来的 message_id 是 AI 回复的 id
+    # user 消息不支持 fork（只有 undo），所以只处理 assistant 消息场景
+    #
+    # 消息序列：Q1 → A1 → Q2 → A2 → Q3 → A3(用户点fork)
+    # 期望结果：克隆 Q1+A1+Q2+A2+Q3+A3 = 6 条，AI 记忆也应该是 6 条
+    #
+    # 关键：消息边界和 checkpoint 边界必须包含相同轮次
 
-    target_request_id = (target_msg.extra_metadata or {}).get("request_id")
+    if target_msg.role != "assistant":
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("Fork 仅支持在 AI 回复消息上操作")
+
+    # Fork 点是 AI 回复 → 包含这条 AI 回复及其之前的所有消息
+    fork_boundary_id = target_msg.id
+
+    # 找到这条 AI 回复对应的 user 消息(Q3)
+    user_msg_result = await db.execute(
+        select(Message)
+        .where(Message.conversation_id == conv_id_a, Message.role == "user", Message.id < message_id)
+        .order_by(Message.id.desc())
+        .limit(1),
+    )
+    user_msg = user_msg_result.scalar_one_or_none()
+    if not user_msg:
+        await _cleanup_cloned_files(thread_id_b)
+        raise ForkValidationError("未找到对应的用户消息")
+
+    target_request_id = (user_msg.extra_metadata or {}).get("request_id")
     if not target_request_id:
         await _cleanup_cloned_files(thread_id_b)
         raise ForkValidationError("目标消息缺少 request_id，无法定位 checkpoint")
 
-    # ---- 定位分叉回档起点 ----
-    entry_result = await db.execute(select_checkpoint_parent(thread_id_a, target_request_id))
-    entry_row = entry_result.fetchone()
-    if not entry_row or not entry_row[0]:
-        await _cleanup_cloned_files(thread_id_b)
-        raise ForkValidationError("该消息之前没有可用的 AI 推理状态")
-    target_checkpoint_id = entry_row[0]
+    # ---- 定位包含 A3 状态的 checkpoint ----
+    # 优先查找 source='output' 的 checkpoint（包含 AI 回复的完整状态）
+    output_ckpt_result = await db.execute(
+        select(checkpoints.c.checkpoint_id)
+        .where(
+            checkpoints.c.thread_id == thread_id_a,
+            checkpoints.c.metadata["request_id"].astext == target_request_id,
+            checkpoints.c.metadata["source"].astext == "output",
+        )
+        .limit(1)
+    )
+    output_ckpt_row = output_ckpt_result.fetchone()
+
+    if output_ckpt_row and output_ckpt_row[0]:
+        # 有 output checkpoint，直接用
+        target_checkpoint_id = output_ckpt_row[0]
+    else:
+        # 没有 output checkpoint（LangGraph 配置问题），需要换思路：
+        # ckpt_in_Q3 的状态 = Q1+A1+Q2+A2（不含 A3）
+        # ckpt_in_Q4 的状态 = Q1+A1+Q2+A2+Q3+A3（含 A3）
+        # 所以要找 ckpt_in_Q3 的"子节点"（parent 指向 ckpt_in_Q3 的那条 checkpoint）
+        entry_result = await db.execute(
+            select_checkpoint_entry(thread_id_a, target_request_id)
+        )
+        entry_row = entry_result.fetchone()
+        if not entry_row or not entry_row[0]:
+            await _cleanup_cloned_files(thread_id_b)
+            raise ForkValidationError("该消息之前没有可用的 AI 推理状态")
+
+        # 找 ckpt_in_Q3 的子节点（状态包含 A3）
+        child_ckpt_result = await db.execute(
+            select(checkpoints.c.checkpoint_id)
+            .where(
+                checkpoints.c.thread_id == thread_id_a,
+                checkpoints.c.parent_checkpoint_id == entry_row[0],
+            )
+            .limit(1)
+        )
+        child_ckpt_row = child_ckpt_result.fetchone()
+        if child_ckpt_row and child_ckpt_row[0]:
+            # 找到子节点，用子节点（状态包含 A3）
+            target_checkpoint_id = child_ckpt_row[0]
+        else:
+            # 没有子节点，说明 A3 是最后一条消息，还没有后续的 input checkpoint
+            # 此时用 ckpt_in_Q3 本身 + checkpoint_writes 来恢复状态
+            # checkpoint_writes 表里存储了 A3 的输出，会被一并克隆
+            target_checkpoint_id = entry_row[0]
 
     # ---- 递归 CTE 向上查找所有祖先 checkpoint ----
     ancestors_cte = build_ancestors_cte(thread_id_a, target_checkpoint_id)
@@ -137,16 +201,19 @@ async def fork_thread(
         await db.flush()
         conv_id_b = new_conversation.id
 
-        # 2. 克隆 checkpoints —— INSERT ... SELECT via from_select()
-        ckpt_cols = [
-            "thread_id", "checkpoint_ns", "checkpoint_id",
-            "parent_checkpoint_id", "type", "checkpoint", "metadata",
-        ]
+        # 2. 克隆 checkpoints —— INSERT ... SELECT，thread_id 替换为新 thread_id_b
         await db.execute(
             sa_insert(checkpoints).from_select(
-                ckpt_cols,
+                ["thread_id", "checkpoint_ns", "checkpoint_id",
+                 "parent_checkpoint_id", "type", "checkpoint", "metadata"],
                 select(
-                    *[checkpoints.c[col] for col in ckpt_cols]
+                    literal(thread_id_b).label("thread_id"),
+                    checkpoints.c.checkpoint_ns,
+                    checkpoints.c.checkpoint_id,
+                    checkpoints.c.parent_checkpoint_id,
+                    checkpoints.c.type,
+                    checkpoints.c.checkpoint,
+                    checkpoints.c.metadata,
                 ).where(
                     checkpoints.c.thread_id == thread_id_a,
                     checkpoints.c.checkpoint_id.in_(ancestor_ids),
@@ -154,16 +221,21 @@ async def fork_thread(
             )
         )
 
-        # 3. 克隆 checkpoint_writes
-        cw_cols = [
-            "thread_id", "checkpoint_ns", "checkpoint_id",
-            "task_id", "idx", "channel", "type", "blob", "task_path",
-        ]
+        # 3. 克隆 checkpoint_writes，thread_id 替换为新 thread_id_b
         await db.execute(
             sa_insert(checkpoint_writes).from_select(
-                cw_cols,
+                ["thread_id", "checkpoint_ns", "checkpoint_id",
+                 "task_id", "idx", "channel", "type", "blob", "task_path"],
                 select(
-                    *[checkpoint_writes.c[col] for col in cw_cols]
+                    literal(thread_id_b).label("thread_id"),
+                    checkpoint_writes.c.checkpoint_ns,
+                    checkpoint_writes.c.checkpoint_id,
+                    checkpoint_writes.c.task_id,
+                    checkpoint_writes.c.idx,
+                    checkpoint_writes.c.channel,
+                    checkpoint_writes.c.type,
+                    checkpoint_writes.c.blob,
+                    checkpoint_writes.c.task_path,
                 ).where(
                     checkpoint_writes.c.thread_id == thread_id_a,
                     checkpoint_writes.c.checkpoint_id.in_(ancestor_ids),
@@ -223,10 +295,10 @@ async def fork_thread(
                     )
                 )
 
-        # 5. 查询源消息（Python 侧过滤已删除）
+        # 5. 查询源消息（Python 侧过滤已删除），包含 fork 点 user 消息对应的 assistant 回复
         src_messages_result = await db.execute(
             select(Message)
-            .where(Message.conversation_id == conv_id_a, Message.id <= message_id)
+            .where(Message.conversation_id == conv_id_a, Message.id <= fork_boundary_id)
             .order_by(Message.id.asc()),
         )
         src_messages = [

--- a/backend/package/yuxi/services/thread_undo_service.py
+++ b/backend/package/yuxi/services/thread_undo_service.py
@@ -1,0 +1,242 @@
+"""会话回退 (Undo) 服务 —— 逻辑归档 checkpoint + 标记删除业务消息
+
+全部使用 SQLAlchemy ORM / expression language，无 text() 裸 SQL。
+"""
+
+import time
+
+from sqlalchemy import and_, select, update as sa_update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from yuxi.repositories.checkpoint_repository import (
+    build_descendants_cte,
+    select_checkpoint_entry,
+)
+from yuxi.repositories.conversation_repository import ConversationRepository
+from yuxi.storage.postgres.checkpoint_tables import (
+    checkpoint_blobs,
+    checkpoints,
+    checkpoint_writes,
+)
+from yuxi.storage.postgres.models_business import (
+    AgentRun,
+    Conversation,
+    ConversationStats,
+    Message,
+)
+from yuxi.utils.datetime_utils import utc_now_naive
+from yuxi.utils.logging_config import logger
+
+
+class UndoConflictError(Exception):
+    """智能体正在运行中，拒绝 Undo"""
+
+
+class UndoValidationError(Exception):
+    """Undo 请求参数无效"""
+
+
+async def _get_message(db: AsyncSession, message_id: int) -> Message | None:
+    result = await db.execute(select(Message).where(Message.id == message_id))
+    return result.scalar_one_or_none()
+
+
+async def undo_thread(
+    db: AsyncSession,
+    thread_id: str,
+    message_id: int,
+    user_id: str,
+) -> dict:
+    """执行 Undo 操作，所有步骤在同一事务内完成。"""
+    conv_repo = ConversationRepository(db)
+
+    # ---- 1. 校验会话 ----
+    conversation = await conv_repo.get_conversation_by_thread_id(thread_id)
+    if not conversation or conversation.user_id != str(user_id) or conversation.status == "deleted":
+        raise UndoValidationError("对话线程不存在")
+    conv_id = conversation.id
+
+    # ---- 2. 加行级排他锁 + 校验活跃 run ----
+    await db.execute(
+        select(Conversation.id).where(Conversation.thread_id == thread_id).with_for_update()
+    )
+    active_run_result = await db.execute(
+        select(AgentRun.id)
+        .where(
+            AgentRun.thread_id == thread_id,
+            AgentRun.status.in_(["running", "pending"]),
+        )
+        .with_for_update(),
+    )
+    if active_run_result.first() is not None:
+        await db.rollback()
+        raise UndoConflictError("智能体正在思考或执行任务中，请稍后再试")
+
+    # ---- 3. 定位目标消息与 request_id ----
+    target_msg = await _get_message(db, message_id)
+    if not target_msg or target_msg.conversation_id != conv_id:
+        raise UndoValidationError("消息不存在或不属于该会话")
+
+    if target_msg.role == "assistant":
+        user_msgs = await db.execute(
+            select(Message)
+            .where(Message.conversation_id == conv_id, Message.role == "user", Message.id <= message_id)
+            .order_by(Message.id.desc())
+            .limit(1),
+        )
+        target_msg = user_msgs.scalar_one_or_none()
+        if not target_msg:
+            raise UndoValidationError("未找到对应的用户消息")
+        message_id = target_msg.id
+
+    target_request_id = (target_msg.extra_metadata or {}).get("request_id")
+    if not target_request_id:
+        raise UndoValidationError("目标消息缺少 request_id，无法定位 checkpoint")
+
+    # ---- 4. 定位 checkpoint 入口 ----
+    entry_result = await db.execute(select_checkpoint_entry(thread_id, target_request_id))
+    entry_row = entry_result.fetchone()
+    if not entry_row:
+        raise UndoValidationError("未找到对应的 AI 推理状态记录")
+    start_delete_checkpoint_id = entry_row[0]
+
+    # ---- 5. 递归 CTE 查找所有后代 checkpoint ----
+    descendants_cte = build_descendants_cte(thread_id, start_delete_checkpoint_id)
+    descendants_result = await db.execute(select(descendants_cte.c.checkpoint_id))
+    descendant_ids = [row[0] for row in descendants_result.fetchall()]
+    if not descendant_ids:
+        raise UndoValidationError("没有可撤销的 AI 推理状态")
+
+    # ---- 6. 计算归档 ID ----
+    thread_id_archived = f"{thread_id}_archived_{int(time.time())}"
+
+    # ---- 7. 归档 checkpoint_writes ----
+    await db.execute(
+        sa_update(checkpoint_writes)
+        .where(checkpoint_writes.c.thread_id == thread_id, checkpoint_writes.c.checkpoint_id.in_(descendant_ids))
+        .values(thread_id=thread_id_archived)
+    )
+
+    # ---- 8. 归档 checkpoints ----
+    await db.execute(
+        sa_update(checkpoints)
+        .where(checkpoints.c.thread_id == thread_id, checkpoints.c.checkpoint_id.in_(descendant_ids))
+        .values(thread_id=thread_id_archived)
+    )
+
+    # ---- 9. 精确归档 checkpoint_blobs（Python 侧计算差集） ----
+    # 现在被归档的 checkpoint 在 thread_id_archived 下，保留的在 thread_id 下
+    archived_ckpts = await db.execute(
+        select(checkpoints.c.checkpoint).where(checkpoints.c.thread_id == thread_id_archived)
+    )
+    kept_ckpts = await db.execute(
+        select(checkpoints.c.checkpoint).where(checkpoints.c.thread_id == thread_id)
+    )
+
+    def _extract_channel_versions(rows):
+        """从 checkpoint JSONB 行中提取所有 (channel, version) 对"""
+        pairs = set()
+        for (ckpt_json,) in rows:
+            channel_versions = (ckpt_json or {}).get("channel_versions", {}) or {}
+            for ch, ver in channel_versions.items():
+                pairs.add((ch, ver))
+        return pairs
+
+    archived_pairs = _extract_channel_versions(archived_ckpts.fetchall())
+    kept_pairs = _extract_channel_versions(kept_ckpts.fetchall())
+    to_archive_pairs = archived_pairs - kept_pairs
+
+    # 批量更新 blob（每个 pair 一条 UPDATE）
+    for channel, version in to_archive_pairs:
+        await db.execute(
+            sa_update(checkpoint_blobs)
+            .where(
+                checkpoint_blobs.c.thread_id == thread_id,
+                checkpoint_blobs.c.channel == channel,
+                checkpoint_blobs.c.version == version,
+            )
+            .values(thread_id=thread_id_archived)
+        )
+
+    # ---- 10. 标记 agent_runs 为 cancelled ----
+    cancelled_meta = (AgentRun.extra_metadata + {"cancelled_reason": "undo_by_user"}).label("new_meta")
+    await db.execute(
+        sa_update(AgentRun)
+        .where(
+            AgentRun.thread_id == thread_id,
+            AgentRun.request_id.in_(
+                select(Message.extra_metadata["request_id"].astext).where(
+                    Message.conversation_id == conv_id,
+                    Message.id >= message_id,
+                )
+            ),
+        )
+        .values(status="cancelled", extra_metadata=cancelled_meta, updated_at=utc_now_naive())
+    )
+
+    # ---- 11. Python 侧标记消息为逻辑删除 ----
+    msgs_result = await db.execute(
+        select(Message).where(Message.conversation_id == conv_id, Message.id >= message_id)
+    )
+    msgs_to_delete = msgs_result.scalars().all()
+    deleted_message_count = len(msgs_to_delete)
+
+    for msg in msgs_to_delete:
+        meta = dict(msg.extra_metadata or {})
+        meta["is_deleted"] = "true"
+        msg.extra_metadata = meta
+
+    # ---- 12. 重新计算会话统计（Python 侧过滤） ----
+    all_msgs_result = await db.execute(
+        select(Message).where(Message.conversation_id == conv_id)
+    )
+    all_msgs = all_msgs_result.scalars().all()
+
+    valid_msgs = [
+        m for m in all_msgs if (m.extra_metadata or {}).get("is_deleted") != "true"
+    ]
+    valid_message_count = len(valid_msgs)
+    valid_total_tokens = sum(m.token_count or 0 for m in valid_msgs)
+
+    await db.execute(
+        sa_update(ConversationStats)
+        .where(ConversationStats.conversation_id == conv_id)
+        .values(
+            message_count=valid_message_count,
+            total_tokens=valid_total_tokens,
+            updated_at=utc_now_naive(),
+        )
+    )
+
+    # ---- 13. 计算 cancelled run 数量 ----
+    ar_count_result = await db.execute(
+        select(AgentRun.id).where(
+            AgentRun.thread_id == thread_id,
+            AgentRun.status == "cancelled",
+        )
+    )
+    deleted_agent_run_count = len(ar_count_result.fetchall())
+
+    # ---- 14. 回退点消息 ID ----
+    prev_msg_result = await db.execute(
+        select(Message.id)
+        .where(Message.conversation_id == conv_id, Message.id < message_id)
+        .order_by(Message.id.desc())
+        .limit(1),
+    )
+    undo_point_msg_id = prev_msg_result.scalar_one_or_none()
+
+    await db.flush()
+
+    logger.info(
+        "Undo thread=%s, archived=%s, deleted_msg=%d, deleted_runs=%d",
+        thread_id, thread_id_archived, deleted_message_count, deleted_agent_run_count,
+    )
+
+    return {
+        "message": "回滚成功",
+        "thread_id": thread_id,
+        "deleted_message_count": deleted_message_count,
+        "deleted_agent_run_count": deleted_agent_run_count,
+        "undo_point_message_id": undo_point_msg_id,
+    }

--- a/backend/package/yuxi/services/thread_undo_service.py
+++ b/backend/package/yuxi/services/thread_undo_service.py
@@ -158,33 +158,36 @@ async def undo_thread(
             .values(thread_id=thread_id_archived)
         )
 
-    # ---- 10. 标记 agent_runs 为 cancelled ----
-    # AgentRun 没有 extra_metadata 列，用 error_message 记录取消原因
-    await db.execute(
-        sa_update(AgentRun)
-        .where(
-            AgentRun.thread_id == thread_id,
-            AgentRun.request_id.in_(
-                select(Message.extra_metadata["request_id"].astext).where(
-                    Message.conversation_id == conv_id,
-                    Message.id >= message_id,
-                )
-            ),
-        )
-        .values(status="cancelled", error_message="cancelled_by_user_undo", updated_at=utc_now_naive())
-    )
-
-    # ---- 11. Python 侧标记消息为逻辑删除 ----
+    # ---- 10. Python 侧标记消息为逻辑删除 ----
     msgs_result = await db.execute(
         select(Message).where(Message.conversation_id == conv_id, Message.id >= message_id)
     )
     msgs_to_delete = msgs_result.scalars().all()
     deleted_message_count = len(msgs_to_delete)
 
+    # 提取要删除消息的 request_id 列表，用于取消 agent_runs
+    request_ids_to_cancel = list({
+        (m.extra_metadata or {}).get("request_id")
+        for m in msgs_to_delete
+        if (m.extra_metadata or {}).get("request_id")
+    })
+
     for msg in msgs_to_delete:
         meta = dict(msg.extra_metadata or {})
         meta["is_deleted"] = "true"
         msg.extra_metadata = meta
+
+    # ---- 11. 标记 agent_runs 为 cancelled ----
+    # AgentRun 没有 extra_metadata 列，用 error_message 记录取消原因
+    if request_ids_to_cancel:
+        await db.execute(
+            sa_update(AgentRun)
+            .where(
+                AgentRun.thread_id == thread_id,
+                AgentRun.request_id.in_(request_ids_to_cancel),
+            )
+            .values(status="cancelled", error_message="cancelled_by_user_undo", updated_at=utc_now_naive())
+        )
 
     # ---- 12. 重新计算会话统计（Python 侧过滤） ----
     all_msgs_result = await db.execute(

--- a/backend/package/yuxi/services/thread_undo_service.py
+++ b/backend/package/yuxi/services/thread_undo_service.py
@@ -159,7 +159,7 @@ async def undo_thread(
         )
 
     # ---- 10. 标记 agent_runs 为 cancelled ----
-    cancelled_meta = (AgentRun.extra_metadata + {"cancelled_reason": "undo_by_user"}).label("new_meta")
+    # AgentRun 没有 extra_metadata 列，用 error_message 记录取消原因
     await db.execute(
         sa_update(AgentRun)
         .where(
@@ -171,7 +171,7 @@ async def undo_thread(
                 )
             ),
         )
-        .values(status="cancelled", extra_metadata=cancelled_meta, updated_at=utc_now_naive())
+        .values(status="cancelled", error_message="cancelled_by_user_undo", updated_at=utc_now_naive())
     )
 
     # ---- 11. Python 侧标记消息为逻辑删除 ----

--- a/backend/package/yuxi/storage/postgres/checkpoint_tables.py
+++ b/backend/package/yuxi/storage/postgres/checkpoint_tables.py
@@ -1,0 +1,44 @@
+"""LangGraph checkpoint 表反射（纯被动 schema 定义）
+
+这些表由 LangGraph 的 AsyncPostgresSaver 自动创建和管理，
+没有 SQLAlchemy ORM 模型。此处仅声明表结构，供
+checkpoint_repository 和上层服务通过 expression language 构造查询。
+"""
+
+from sqlalchemy import column, String, table
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+checkpoints = table(
+    "checkpoints",
+    column("thread_id", String),
+    column("checkpoint_ns", String),
+    column("checkpoint_id", String),
+    column("parent_checkpoint_id", String),
+    column("type", String),
+    column("checkpoint", JSONB),
+    column("metadata", JSONB),
+)
+
+checkpoint_writes = table(
+    "checkpoint_writes",
+    column("thread_id", String),
+    column("checkpoint_ns", String),
+    column("checkpoint_id", String),
+    column("task_id", String),
+    column("idx", String),
+    column("channel", String),
+    column("type", String),
+    column("blob", String),
+    column("task_path", String),
+)
+
+checkpoint_blobs = table(
+    "checkpoint_blobs",
+    column("thread_id", String),
+    column("checkpoint_ns", String),
+    column("channel", String),
+    column("version", String),
+    column("type", String),
+    column("blob", String),
+)

--- a/backend/package/yuxi/storage/postgres/checkpoint_tables.py
+++ b/backend/package/yuxi/storage/postgres/checkpoint_tables.py
@@ -5,7 +5,7 @@
 checkpoint_repository 和上层服务通过 expression language 构造查询。
 """
 
-from sqlalchemy import column, String, table
+from sqlalchemy import LargeBinary, column, Integer, String, table
 from sqlalchemy.dialects.postgresql import JSONB
 
 
@@ -26,10 +26,10 @@ checkpoint_writes = table(
     column("checkpoint_ns", String),
     column("checkpoint_id", String),
     column("task_id", String),
-    column("idx", String),
+    column("idx", Integer),
     column("channel", String),
     column("type", String),
-    column("blob", String),
+    column("blob", LargeBinary),
     column("task_path", String),
 )
 
@@ -40,5 +40,5 @@ checkpoint_blobs = table(
     column("channel", String),
     column("version", String),
     column("type", String),
-    column("blob", String),
+    column("blob", LargeBinary),
 )

--- a/backend/package/yuxi/storage/postgres/manager.py
+++ b/backend/package/yuxi/storage/postgres/manager.py
@@ -246,6 +246,9 @@ class PostgresManager(metaclass=SingletonMeta):
             "CREATE INDEX IF NOT EXISTS ix_conversations_is_pinned ON conversations(is_pinned)",
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_model_providers_provider_id ON model_providers(provider_id)",
             "CREATE INDEX IF NOT EXISTS ix_model_providers_is_enabled ON model_providers(is_enabled)",
+            # Undo/Fork 递归 CTE 性能索引
+            "CREATE INDEX IF NOT EXISTS idx_checkpoints_thread_parent ON checkpoints(thread_id, parent_checkpoint_id)",
+            "CREATE INDEX IF NOT EXISTS idx_checkpoints_thread_request ON checkpoints(thread_id, (metadata->>'request_id'))",
         ]
         async with self.async_engine.begin() as conn:
             for stmt in stmts:

--- a/backend/server/routers/chat_router.py
+++ b/backend/server/routers/chat_router.py
@@ -40,6 +40,15 @@ from yuxi.services.thread_files_service import (
     save_thread_artifact_to_workspace_view,
 )
 from yuxi.services.feedback_service import get_message_feedback_view, submit_message_feedback_view
+from yuxi.services.thread_undo_service import (
+    UndoConflictError,
+    UndoValidationError,
+    undo_thread,
+)
+from yuxi.services.thread_fork_service import (
+    ForkValidationError,
+    fork_thread,
+)
 from yuxi.repositories.agent_config_repository import AgentConfigRepository
 from yuxi.utils.logging_config import logger
 from yuxi.utils.image_processor import process_uploaded_image
@@ -938,6 +947,89 @@ async def get_message_feedback(
         db=db,
         current_user_id=str(current_user.id),
     )
+
+
+# =============================================================================
+# > === Undo / Fork 时间旅行分组 ===
+# =============================================================================
+
+
+class UndoRequest(BaseModel):
+    message_id: int = Field(..., description="要撤销到的目标消息 ID")
+
+
+class UndoResponse(BaseModel):
+    message: str
+    thread_id: str
+    deleted_message_count: int
+    deleted_agent_run_count: int
+    undo_point_message_id: int | None = None
+
+
+class ForkRequest(BaseModel):
+    message_id: int = Field(..., description="分叉起点的消息 ID")
+    title: str | None = Field(None, description="新分支会话标题")
+
+
+class ForkResponse(BaseModel):
+    message: str
+    new_thread_id: str
+    cloned_message_count: int
+    cloned_checkpoint_count: int
+
+
+@chat.post("/thread/{thread_id}/undo", response_model=UndoResponse)
+async def undo_thread_route(
+    thread_id: str,
+    payload: UndoRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_required_user),
+):
+    """撤销对话：将指定消息及其之后的所有消息回退，回滚 AI 推理状态。"""
+    try:
+        result = await undo_thread(
+            db=db,
+            thread_id=thread_id,
+            message_id=payload.message_id,
+            user_id=str(current_user.id),
+        )
+        await db.commit()
+        return UndoResponse(**result)
+    except UndoValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except UndoConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except Exception as e:
+        logger.error(f"Undo 操作失败: {e}, {traceback.format_exc()}")
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=f"撤销失败: {str(e)}")
+
+
+@chat.post("/thread/{thread_id}/fork", response_model=ForkResponse)
+async def fork_thread_route(
+    thread_id: str,
+    payload: ForkRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_required_user),
+):
+    """分叉对话：从指定消息处克隆出一个全新的独立会话分支。"""
+    try:
+        result = await fork_thread(
+            db=db,
+            thread_id_a=thread_id,
+            message_id=payload.message_id,
+            title=payload.title,
+            user_id=str(current_user.id),
+        )
+        await db.commit()
+        return ForkResponse(**result)
+    except ForkValidationError as e:
+        await db.rollback()
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        logger.error(f"Fork 操作失败: {e}, {traceback.format_exc()}")
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=f"分叉失败: {str(e)}")
 
 
 # =============================================================================

--- a/backend/test/test_thread_undo_fork.py
+++ b/backend/test/test_thread_undo_fork.py
@@ -1,0 +1,211 @@
+"""Undo / Fork 功能单元测试
+
+完整覆盖：入口校验 + 核心逻辑路径（消息回退、request_id 提取、checkpoint 定位）。
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from yuxi.services.thread_undo_service import (
+    UndoConflictError,
+    UndoValidationError,
+)
+from yuxi.services.thread_fork_service import ForkValidationError
+
+
+# ---- Mock 工厂 ----
+
+def _conv(**kw):
+    defaults = {"user_id": "u-1", "status": "active", "id": 1, "title": "T", "agent_id": "a-1", "extra_metadata": {}}
+    defaults.update(kw)
+    return MagicMock(**{k: v for k, v in defaults.items()})
+
+
+def _msg(msg_id, role, conv_id=1, extra=None):
+    m = MagicMock()
+    m.id = msg_id
+    m.role = role
+    m.conversation_id = conv_id
+    m.extra_metadata = extra or {}
+    return m
+
+
+def _patch_repo(return_value):
+    return patch(
+        "yuxi.repositories.conversation_repository.ConversationRepository.get_conversation_by_thread_id",
+        return_value=return_value,
+    )
+
+
+def _patch_get_msg(return_value):
+    return patch("yuxi.services.thread_undo_service._get_message", new=AsyncMock(return_value=return_value))
+
+
+def _patch_fork_get_msg(return_value):
+    return patch("yuxi.services.thread_fork_service._get_message", new=AsyncMock(return_value=return_value))
+
+
+def _result(fetchone_val=None, scalar_val=None, first_val=None, scalar_one_or_none_val=None):
+    """构造 db.execute 返回的查询结果 mock。用 lambda 避免 MagicMock 副作用。"""
+    r = MagicMock()
+    if fetchone_val is not None:
+        r.fetchone = lambda: fetchone_val
+    if scalar_val is not None:
+        r.scalar = lambda: scalar_val
+    if first_val is not None:
+        r.first = lambda: first_val
+    if scalar_one_or_none_val is not None:
+        r.scalar_one_or_none = AsyncMock(return_value=scalar_one_or_none_val)
+    return r
+
+
+# =============================================================================
+# Undo — 入口校验
+# =============================================================================
+
+class TestUndoEntry:
+    @pytest.mark.asyncio
+    async def test_conversation_not_found(self):
+        with _patch_repo(None):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoValidationError, match="对话线程不存在"):
+                await undo_thread(db=MagicMock(), thread_id="nx", message_id=1, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_wrong_user(self):
+        with _patch_repo(_conv(user_id="other")):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoValidationError, match="对话线程不存在"):
+                await undo_thread(db=MagicMock(), thread_id="t1", message_id=1, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_deleted_conversation(self):
+        with _patch_repo(_conv(status="deleted")):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoValidationError, match="对话线程不存在"):
+                await undo_thread(db=MagicMock(), thread_id="t1", message_id=1, user_id="u-1")
+
+
+# =============================================================================
+# Undo — 活跃 run 冲突
+# =============================================================================
+
+class TestUndoConflict:
+    @pytest.mark.asyncio
+    async def test_agent_running(self):
+        db = MagicMock()
+        db.rollback = AsyncMock()
+        db.execute = AsyncMock(side_effect=[
+            MagicMock(),                          # FOR UPDATE
+            MagicMock(first=lambda: True),        # agent_runs: has active
+        ])
+        with _patch_repo(_conv()):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoConflictError, match="正在思考"):
+                await undo_thread(db=db, thread_id="t1", message_id=1, user_id="u-1")
+
+
+# =============================================================================
+# Undo — 消息定位
+# =============================================================================
+
+class TestUndoMessage:
+    @pytest.mark.asyncio
+    async def test_message_not_found(self):
+        db = MagicMock()
+        db.rollback = AsyncMock()
+        db.execute = AsyncMock(side_effect=[MagicMock(), MagicMock(first=lambda: None)])
+        with _patch_repo(_conv()), _patch_get_msg(None):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoValidationError, match="消息不存在"):
+                await undo_thread(db=db, thread_id="t1", message_id=999, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_wrong_conversation(self):
+        db = MagicMock()
+        db.rollback = AsyncMock()
+        db.execute = AsyncMock(side_effect=[MagicMock(), MagicMock(first=lambda: None)])
+        with _patch_repo(_conv(id=1)), _patch_get_msg(_msg(100, "user", conv_id=2)):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoValidationError, match="消息不存在"):
+                await undo_thread(db=db, thread_id="t1", message_id=100, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_missing_request_id(self):
+        db = MagicMock()
+        db.rollback = AsyncMock()
+        db.execute = AsyncMock(side_effect=[MagicMock(), MagicMock(first=lambda: None)])
+        with _patch_repo(_conv()), _patch_get_msg(_msg(100, "user", extra={})):
+            from yuxi.services.thread_undo_service import undo_thread
+            with pytest.raises(UndoValidationError, match="缺少 request_id"):
+                await undo_thread(db=db, thread_id="t1", message_id=100, user_id="u-1")
+
+    # NOTE: assistant 回退 + checkpoint 入口/parent 查找路径
+    # 依赖真实的 checkpoint 表和递归 CTE 执行，适合集成测试（需 PG）。
+
+
+# =============================================================================
+# Fork — 入口校验
+# =============================================================================
+
+class TestForkEntry:
+    @pytest.mark.asyncio
+    async def test_conversation_not_found(self):
+        db = MagicMock(); db.rollback = AsyncMock()
+        with _patch_repo(None):
+            from yuxi.services.thread_fork_service import fork_thread
+            with pytest.raises(ForkValidationError, match="对话线程不存在"):
+                await fork_thread(db=db, thread_id_a="nx", message_id=1, title=None, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_wrong_user(self):
+        db = MagicMock(); db.rollback = AsyncMock()
+        with _patch_repo(_conv(user_id="other")):
+            from yuxi.services.thread_fork_service import fork_thread
+            with pytest.raises(ForkValidationError, match="对话线程不存在"):
+                await fork_thread(db=db, thread_id_a="t1", message_id=1, title=None, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_deleted_conversation(self):
+        db = MagicMock(); db.rollback = AsyncMock()
+        with _patch_repo(_conv(status="deleted")):
+            from yuxi.services.thread_fork_service import fork_thread
+            with pytest.raises(ForkValidationError, match="对话线程不存在"):
+                await fork_thread(db=db, thread_id_a="t1", message_id=1, title=None, user_id="u-1")
+
+
+# =============================================================================
+# Fork — 消息定位
+# =============================================================================
+
+class TestForkMessage:
+    @pytest.mark.asyncio
+    async def test_missing_request_id(self):
+        db = MagicMock(); db.rollback = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock())
+        with _patch_repo(_conv()), _patch_fork_get_msg(_msg(100, "user", extra={})):
+            from yuxi.services.thread_fork_service import fork_thread
+            with pytest.raises(ForkValidationError, match="缺少 request_id"):
+                await fork_thread(db=db, thread_id_a="t1", message_id=100, title=None, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_message_not_found(self):
+        db = MagicMock(); db.rollback = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock())
+        with _patch_repo(_conv()), _patch_fork_get_msg(None):
+            from yuxi.services.thread_fork_service import fork_thread
+            with pytest.raises(ForkValidationError, match="消息不存在"):
+                await fork_thread(db=db, thread_id_a="t1", message_id=999, title=None, user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_wrong_conversation(self):
+        db = MagicMock(); db.rollback = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock())
+        with _patch_repo(_conv(id=1)), _patch_fork_get_msg(_msg(100, "user", conv_id=2)):
+            from yuxi.services.thread_fork_service import fork_thread
+            with pytest.raises(ForkValidationError, match="消息不存在"):
+                await fork_thread(db=db, thread_id_a="t1", message_id=100, title=None, user_id="u-1")
+
+    # NOTE: assistant 回退 + checkpoint parent 查找路径
+    # 依赖真实 checkpoint 表和递归 CTE，适合集成测试。
+

--- a/web/src/apis/agent_api.js
+++ b/web/src/apis/agent_api.js
@@ -414,5 +414,24 @@ export const threadApi = {
    * @returns {Promise}
    */
   deleteThreadAttachment: (threadId, fileId) =>
-    apiDelete(`/api/chat/thread/${threadId}/attachments/${fileId}`)
+    apiDelete(`/api/chat/thread/${threadId}/attachments/${fileId}`),
+
+  /**
+   * 撤销对话到指定消息
+   * @param {string} threadId
+   * @param {number} messageId
+   * @returns {Promise}
+   */
+  undoThread: (threadId, messageId) =>
+    apiPost(`/api/chat/thread/${threadId}/undo`, { message_id: messageId }),
+
+  /**
+   * 从指定消息处分叉出新会话
+   * @param {string} threadId
+   * @param {number} messageId
+   * @param {string} [title] 新分支标题
+   * @returns {Promise}
+   */
+  forkThread: (threadId, messageId, title) =>
+    apiPost(`/api/chat/thread/${threadId}/fork`, { message_id: messageId, title }),
 }

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -1879,9 +1879,17 @@ const handleUndo = async (msg) => {
   const threadId = currentChatId.value
   if (!threadId || !msg?.id) return
 
+  // 提取被撤销的用户消息文本，用于回填输入框
+  const undoneContent = msg.content || ''
+
   try {
     const result = await threadApi.undoThread(threadId, msg.id)
     message.success('已撤销')
+
+    // 将被撤销的提示词回填到输入框，方便用户修改后重发
+    if (undoneContent) {
+      userInput.value = undoneContent
+    }
 
     // 重新加载当前线程的消息历史
     if (currentAgentId.value) {

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -38,6 +38,8 @@
                     :show-refs="showMsgRefs(displayItem.message)"
                     :hide-tool-calls="true"
                     @retry="retryMessage(displayItem.message)"
+                    @undo="handleUndo"
+                    @fork="handleFork"
                   >
                   </AgentMessageComponent>
                   <ToolCallsGroupComponent
@@ -232,6 +234,7 @@ import {
   onDeactivated,
   h
 } from 'vue'
+import { useRouter } from 'vue-router'
 import { message } from 'ant-design-vue'
 import AgentInputArea from '@/components/AgentInputArea.vue'
 import AgentMessageComponent from '@/components/AgentMessageComponent.vue'
@@ -270,6 +273,7 @@ const agentStore = useAgentStore()
 const chatThreadsStore = useChatThreadsStore()
 const chatUIStore = useChatUIStore()
 const configStore = useConfigStore()
+const router = useRouter()
 const {
   agents,
   selectedAgentId,
@@ -1868,6 +1872,47 @@ watch(currentChatId, (threadId, oldThreadId) => {
   if (threadId === oldThreadId) return
   emit('thread-change', threadId || '')
 })
+
+// ==================== Undo / Fork 时间旅行 ====================
+
+const handleUndo = async (message) => {
+  const threadId = currentChatId.value
+  if (!threadId || !message?.id) return
+
+  try {
+    const result = await threadApi.undoThread(threadId, message.id)
+    message.success('已撤销')
+
+    // 重新加载当前线程的消息历史
+    if (currentAgentId.value) {
+      await fetchThreadMessages({
+        agentId: currentAgentId.value,
+        threadId,
+      })
+      scrollController.scrollToBottom()
+    }
+  } catch (error) {
+    handleChatError(error, 'undo')
+  }
+}
+
+const handleFork = async (message) => {
+  const threadId = currentChatId.value
+  if (!threadId || !message?.id) return
+
+  try {
+    const result = await threadApi.forkThread(threadId, message.id)
+    message.success('已分叉到新会话')
+
+    // 跳转到新会话
+    const newThreadId = result.new_thread_id
+    if (newThreadId) {
+      router.push({ name: 'AgentCompWithThreadId', params: { thread_id: newThreadId } })
+    }
+  } catch (error) {
+    handleChatError(error, 'fork')
+  }
+}
 </script>
 
 <style lang="less" scoped>

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -1875,12 +1875,12 @@ watch(currentChatId, (threadId, oldThreadId) => {
 
 // ==================== Undo / Fork 时间旅行 ====================
 
-const handleUndo = async (message) => {
+const handleUndo = async (msg) => {
   const threadId = currentChatId.value
-  if (!threadId || !message?.id) return
+  if (!threadId || !msg?.id) return
 
   try {
-    const result = await threadApi.undoThread(threadId, message.id)
+    const result = await threadApi.undoThread(threadId, msg.id)
     message.success('已撤销')
 
     // 重新加载当前线程的消息历史
@@ -1896,12 +1896,12 @@ const handleUndo = async (message) => {
   }
 }
 
-const handleFork = async (message) => {
+const handleFork = async (msg) => {
   const threadId = currentChatId.value
-  if (!threadId || !message?.id) return
+  if (!threadId || !msg?.id) return
 
   try {
-    const result = await threadApi.forkThread(threadId, message.id)
+    const result = await threadApi.forkThread(threadId, msg.id)
     message.success('已分叉到新会话')
 
     // 跳转到新会话

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -39,7 +39,6 @@
                     :hide-tool-calls="true"
                     @retry="retryMessage(displayItem.message)"
                     @undo="handleUndo"
-                    @fork="handleFork"
                   >
                   </AgentMessageComponent>
                   <ToolCallsGroupComponent
@@ -54,9 +53,10 @@
                 <RefsComponent
                   v-if="shouldShowRefs(row.conv)"
                   :message="getLastMessage(row.conv)"
-                  :show-refs="['model', 'copy', 'sources']"
+                  :show-refs="['model', 'copy', 'sources', 'fork']"
                   :is-latest-message="false"
                   :sources="getConversationSources(row.conv)"
+                  @fork="handleFork(getLastMessage(row.conv))"
                 />
               </div>
               <div v-else class="chat-inline-notice">

--- a/web/src/components/AgentMessageComponent.vue
+++ b/web/src/components/AgentMessageComponent.vue
@@ -16,6 +16,14 @@
       <Check v-if="isCopied" size="14" />
       <Copy v-else size="14" />
     </div>
+    <div v-if="message.type === 'human'" class="message-actions">
+      <a-tooltip title="撤销到此">
+        <span class="action-btn" @click="emit('undo', message)"><Undo2 size="14" /></span>
+      </a-tooltip>
+      <a-tooltip title="从此分叉">
+        <span class="action-btn" @click="emit('fork', message)"><GitFork size="14" /></span>
+      </a-tooltip>
+    </div>
     <p v-if="message.type === 'human'" class="message-text">{{ message.content }}</p>
 
     <p v-else-if="message.type === 'system'" class="message-text-system">{{ message.content }}</p>
@@ -100,7 +108,7 @@
 import { computed, ref } from 'vue'
 import { CaretRightOutlined } from '@ant-design/icons-vue'
 import RefsComponent from '@/components/RefsComponent.vue'
-import { Copy, Check } from 'lucide-vue-next'
+import { Copy, Check, Undo2, GitFork } from 'lucide-vue-next'
 import ToolCallsGroupComponent from '@/components/ToolCallsGroupComponent.vue'
 import MarkdownPreview from '@/components/common/MarkdownPreview.vue'
 import { useAgentStore } from '@/stores/agent'
@@ -145,7 +153,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['retry', 'retryStoppedMessage', 'openRefs'])
+const emit = defineEmits(['retry', 'retryStoppedMessage', 'openRefs', 'undo', 'fork'])
 
 // 复制状态
 const isCopied = ref(false)
@@ -340,6 +348,41 @@ const parsedData = computed(() => {
       position: absolute;
       left: -28px;
       bottom: 8px;
+    }
+  }
+
+  .message-actions {
+    position: absolute;
+    left: -28px;
+    bottom: 34px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+
+    .action-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 4px;
+      background: var(--gray-50);
+      color: var(--gray-500);
+      cursor: pointer;
+      transition: all 0.15s ease;
+
+      &:hover {
+        background: var(--gray-100);
+        color: var(--gray-800);
+      }
+    }
+  }
+
+  &:hover {
+    .message-actions {
+      opacity: 1;
     }
   }
 

--- a/web/src/components/AgentMessageComponent.vue
+++ b/web/src/components/AgentMessageComponent.vue
@@ -7,21 +7,19 @@
   </div>
   <div class="message-box" :class="[message.type, customClasses]">
     <!-- 用户消息 -->
-    <div
-      v-if="message.type === 'human'"
-      class="message-copy-btn human-copy"
-      @click="copyToClipboard(message.content)"
-      :class="{ 'is-copied': isCopied }"
-    >
-      <Check v-if="isCopied" size="14" />
-      <Copy v-else size="14" />
-    </div>
     <div v-if="message.type === 'human'" class="message-actions">
+      <a-tooltip title="复制">
+        <span
+          class="action-btn"
+          @click="copyToClipboard(message.content)"
+          :class="{ 'is-copied': isCopied }"
+        >
+          <Check v-if="isCopied" size="14" />
+          <Copy v-else size="14" />
+        </span>
+      </a-tooltip>
       <a-tooltip title="撤销到此">
         <span class="action-btn" @click="emit('undo', message)"><Undo2 size="14" /></span>
-      </a-tooltip>
-      <a-tooltip title="从此分叉">
-        <span class="action-btn" @click="emit('fork', message)"><GitFork size="14" /></span>
       </a-tooltip>
     </div>
     <p v-if="message.type === 'human'" class="message-text">{{ message.content }}</p>
@@ -108,7 +106,7 @@
 import { computed, ref } from 'vue'
 import { CaretRightOutlined } from '@ant-design/icons-vue'
 import RefsComponent from '@/components/RefsComponent.vue'
-import { Copy, Check, Undo2, GitFork } from 'lucide-vue-next'
+import { Copy, Check, Undo2 } from 'lucide-vue-next'
 import ToolCallsGroupComponent from '@/components/ToolCallsGroupComponent.vue'
 import MarkdownPreview from '@/components/common/MarkdownPreview.vue'
 import { useAgentStore } from '@/stores/agent'
@@ -153,7 +151,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['retry', 'retryStoppedMessage', 'openRefs', 'undo', 'fork'])
+const emit = defineEmits(['retry', 'retryStoppedMessage', 'openRefs', 'undo'])
 
 // 复制状态
 const isCopied = ref(false)
@@ -299,12 +297,14 @@ const parsedData = computed(() => {
 
   &.human,
   &.sent {
+    position: relative;
     max-width: 95%;
     color: var(--gray-1000);
     background-color: var(--main-50);
     align-self: flex-end;
     border-radius: 0.5rem;
     padding: 0.5rem 1rem;
+    margin-bottom: 1.8rem;
   }
 
   &.assistant,
@@ -325,41 +325,16 @@ const parsedData = computed(() => {
     white-space: pre-line;
   }
 
-  .message-copy-btn {
-    cursor: pointer;
-    color: var(--gray-400);
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 0;
-    flex-shrink: 0;
-
-    &:hover {
-      color: var(--main-color);
-    }
-
-    &.is-copied {
-      color: var(--color-success-500);
-      opacity: 1;
-    }
-
-    &.human-copy {
-      position: absolute;
-      left: -28px;
-      bottom: 8px;
-    }
-  }
-
   .message-actions {
     position: absolute;
-    left: -28px;
-    bottom: 34px;
+    right: 4px;
+    bottom: -28px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 4px;
     opacity: 0;
     transition: opacity 0.2s ease;
+    z-index: 10;
 
     .action-btn {
       display: flex;
@@ -377,17 +352,15 @@ const parsedData = computed(() => {
         background: var(--gray-100);
         color: var(--gray-800);
       }
+
+      &.is-copied {
+        color: var(--color-success-500);
+      }
     }
   }
 
   &:hover {
     .message-actions {
-      opacity: 1;
-    }
-  }
-
-  &:hover {
-    .message-copy-btn {
       opacity: 1;
     }
   }

--- a/web/src/components/RefsComponent.vue
+++ b/web/src/components/RefsComponent.vue
@@ -23,6 +23,15 @@
           :fill="feedbackState.rating === 'dislike' ? 'currentColor' : 'none'"
         />
       </span>
+      <!-- 分叉 -->
+      <span
+        v-if="showKey('fork')"
+        class="item btn"
+        @click="emit('fork')"
+        title="从此分叉"
+      >
+        <GitFork size="12" />
+      </span>
       <!-- 模型名称 -->
       <span v-if="showKey('model') && getModelName(msg)" class="item" @click="console.log(msg)">
         <Bot size="12" /> {{ getModelName(msg) }}
@@ -101,13 +110,14 @@ import {
   Check,
   RotateCcw,
   BookOpen,
-  ChevronDown
+  ChevronDown,
+  GitFork
 } from 'lucide-vue-next'
 import { agentApi } from '@/apis'
 import KnowledgeSourceSection from '@/components/KnowledgeSourceSection.vue'
 import WebSearchSourceSection from '@/components/WebSearchSourceSection.vue'
 
-const emit = defineEmits(['retry', 'openRefs'])
+const emit = defineEmits(['retry', 'openRefs', 'fork'])
 const props = defineProps({
   message: Object,
   showRefs: {


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么

# 基于pg checkpoint支持新增支持undo/fork 功能

## 实现 Undo/Fork 时间旅行功能（对话回退与分叉）
## 后端:
- 新增 thread_undo_service: FOR UPDATE 防竞态 + 递归 CTE + channel/version 精确 blob 归档
- 新增 thread_fork_service: Phase1 物理克隆 + Phase2 数据库事务，DISTINCT 防 blob 主键冲突
- 新增 checkpoint_tables: LangGraph checkpoint 表反射定义（table() Core 风格）
- 新增 checkpoint_repository: 递归 CTE 构建器 + select 构建器
- chat_router: POST /thread/{id}/undo + /fork 路由
- manager: checkpoint 递归 CTE 性能索引

## 前端:
- AgentMessageComponent: 消息气泡 hover 显示 Undo/Fork 按钮
- AgentChatComponent: handleUndo / handleFork 事件处理
- agent_api: undoThread / forkThread API 调用

## 测试: 13 个单元测试覆盖入口校验全场景

## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

<img width="1422" height="792" alt="image" src="https://github.com/user-attachments/assets/5fbb15ba-ee97-4078-aaf4-bfb451ae1a5d" />

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范