### PR TITLE
Feat: 子代理支持 MCP 和 Skills 独立配置及状态隔离

### DIFF
--- a/backend/package/yuxi/agents/middlewares/skills_middleware.py
+++ b/backend/package/yuxi/agents/middlewares/skills_middleware.py
@@ -159,6 +159,8 @@ class SkillsMiddleware(AgentMiddleware):
         skills_context_name: str = "skills",
         enable_skills_prompt: bool = True,
         skills_sources_for_prompt: list[str] | None = None,
+        static_skills: list[str] | None = None,
+        subagent_system_prompt: str | None = None,
     ):
         """初始化中间件
 
@@ -166,11 +168,15 @@ class SkillsMiddleware(AgentMiddleware):
             skills_context_name: 上下文中的 skills 列表字段名称（默认 "skills"）
             enable_skills_prompt: 是否启用 skills 提示段注入（默认 True）
             skills_sources_for_prompt: skills 来源路径（用于提示词展示，默认 ["/home/gem/skills/"]）
+            static_skills: 静态指定的 skills 列表（子代理场景下无需 context 动态加载）
+            subagent_system_prompt: 子智能体系统提示词覆盖
         """
         super().__init__()
         self.skills_context_name = skills_context_name
         self.enable_skills_prompt = enable_skills_prompt
         self.skills_sources_for_prompt = skills_sources_for_prompt or ["/home/gem/skills/"]
+        self.static_skills = static_skills
+        self.subagent_system_prompt = subagent_system_prompt
 
     async def abefore_agent(self, state: SkillsState, runtime) -> dict[str, Any] | None:
         """在 agent 执行前注入 skills 提示词"""
@@ -179,38 +185,58 @@ class SkillsMiddleware(AgentMiddleware):
         # 检查是否需要注入
         if not self.enable_skills_prompt:
             return None
-        if getattr(runtime_context, "_skills_prompt_injected", False):
+
+        # 区别对待：如果 static_skills 不为空，说明这是子智能体的专属 SkillsMiddleware！
+        # 我们使用专属于子智能体本实例的注入状态标志，从而与父 Agent 以及其他子代理进程/线程级别隔离开！
+        injected_flag = "_skills_prompt_injected"
+        if self.static_skills is not None:
+            injected_flag = f"_skills_prompt_injected_sub_{id(self)}"
+        if getattr(runtime_context, injected_flag, False):
+            # if runtime_context and getattr(runtime_context, "_skills_prompt_injected", False):
             return None
+
+        # 基础系统提示词：如果是子代理模式，绝不使用被污染的父 Agent 提示词，而是使用传入的子代理专属提示词
+        if self.subagent_system_prompt is not None:
+            base_prompt = self.subagent_system_prompt
+        else:
+            base_prompt = getattr(runtime_context, "system_prompt", "") or ""
 
         # 从数据库加载 skills 数据（使用缓存）
         dependency_map = await get_dependency_map()
 
         # 获取配置的 skills
-        configured_skills = getattr(runtime_context, self.skills_context_name, None) or []
+        configured_skills = (
+            self.static_skills
+            if self.static_skills is not None
+            else (getattr(runtime_context, self.skills_context_name, None) or [])
+        )
         selected_skills = normalize_selected_skills(configured_skills)
 
+        # 如果没有专属 skills，直接写入专属 system_prompt，防止被父级冲刷
         if not selected_skills:
+            setattr(runtime_context, "system_prompt", base_prompt)
+            setattr(runtime_context, injected_flag, True)
             return None
 
         # 计算 visible_skills
         visible_skills = expand_skill_closure(selected_skills, dependency_map)
 
         if not visible_skills:
+            setattr(runtime_context, "system_prompt", base_prompt)
+            setattr(runtime_context, injected_flag, True)
             return None
 
         # 收集提示词元数据并构建提示段
         skills_meta = await self._collect_prompt_metadata(visible_skills)
         skills_section = self._build_skills_section(skills_meta)
 
-        # 注入提示词
-        base_prompt = getattr(runtime_context, "system_prompt", "") or ""
+        # 注入提示词并强制覆盖写入 runtime_context.system_prompt，确保接下来子智能体模型调用能够拿到正确的提示词
         merged_prompt = f"{base_prompt}\n\n{skills_section}" if base_prompt else skills_section
         setattr(runtime_context, "system_prompt", merged_prompt)
-        setattr(runtime_context, "_skills_prompt_injected", True)
+        setattr(runtime_context, injected_flag, True)
 
         # 存储 visible_skills 供后续使用
         setattr(runtime_context, "_visible_skills", visible_skills)
-
         return None
 
     async def awrap_model_call(
@@ -219,18 +245,43 @@ class SkillsMiddleware(AgentMiddleware):
         """包装模型调用，处理动态激活和依赖展开"""
         runtime_context = request.runtime.context
 
+        # 如果是子代理模式，将我们在 abefore_agent 中拼接了专属 Skill 元信息的 system_prompt
+        # 写入模型请求的 system_message 中。为避免吞掉其他中间件的修改，此处采用安全合并或追加策略。
+        if self.static_skills is not None:
+            subagent_prompt = getattr(runtime_context, "system_prompt", "")
+            if subagent_prompt and subagent_prompt not in (request.system_message or ""):
+                if not request.system_message or request.system_message == self.subagent_system_prompt:
+                    request = request.override(system_message=subagent_prompt)
+                else:
+                    # 提取专属技能提示词段并安全追加，避免覆盖其他中间件的修改
+                    if self.subagent_system_prompt and subagent_prompt.startswith(self.subagent_system_prompt):
+                        skills_section = subagent_prompt[len(self.subagent_system_prompt) :].lstrip()
+                        if skills_section and skills_section not in request.system_message:
+                            request = request.override(system_message=f"{request.system_message}\n\n{skills_section}")
+                    else:
+                        request = request.override(system_message=subagent_prompt)
         # 从缓存加载 skills 数据
         dependency_map = await get_dependency_map()
 
         # 1. 获取配置的 skills
-        configured_skills = getattr(runtime_context, self.skills_context_name, None) or []
+        configured_skills = (
+            self.static_skills
+            if self.static_skills is not None
+            else (getattr(runtime_context, self.skills_context_name, None) or [])
+        )
         configured = normalize_selected_skills(configured_skills)
 
         # 2. 获取运行时动态激活的 skills
-        state = request.state if isinstance(request.state, dict) else {}
-        activated = state.get("activated_skills", []) or []
-        if not isinstance(activated, list):
-            activated = []
+        if self.static_skills is not None:
+            # 在子代理模式下，静态配置的 skills 已经在编译期由 subagent_service.py 解析并注册到 Graph
+            # 这里在运行时只需获取动态激活（例如通过 read_file 激活）的额外技能，以消除双重执行和不必要的 IO 开销
+            activated_dynamic = getattr(runtime_context, "_subagent_activated_skills", None) or []
+            activated = normalize_selected_skills(activated_dynamic)
+        else:
+            state = request.state if isinstance(request.state, dict) else {}
+            activated = state.get("activated_skills", []) or []
+            if not isinstance(activated, list):
+                activated = []
 
         # 3. 合并并展开闭包
         all_skills = normalize_selected_skills(configured + activated)
@@ -375,7 +426,7 @@ class SkillsMiddleware(AgentMiddleware):
             return result
 
         logger.debug(f"SkillsMiddleware: activated skill by read_file: {slug}")
-        return self._merge_activated_skill_update(result, slug)
+        return self._merge_activated_skill_update(result, slug, request.runtime.context)
 
     async def awrap_tool_call(
         self,
@@ -421,19 +472,33 @@ class SkillsMiddleware(AgentMiddleware):
     def _is_visible_skill_slug(self, request: ToolCallRequest, slug: str) -> bool:
         """检查 slug 是否可见"""
         runtime_context = request.runtime.context
-        visible_skills = getattr(runtime_context, "_visible_skills", None)
+        visible_skills = getattr(runtime_context, "_visible_skills", None) if runtime_context else None
 
         if isinstance(visible_skills, list):
             return slug in visible_skills
 
         # 后备：从配置的 skills 检查
-        configured_skills = getattr(runtime_context, self.skills_context_name, None) or []
+        configured_skills = (
+            self.static_skills
+            if self.static_skills is not None
+            else (getattr(runtime_context, self.skills_context_name, None) or [])
+        )
         normalized = normalize_selected_skills(configured_skills)
         return slug in normalized
 
-    def _merge_activated_skill_update(self, result: Any, slug: str):
+    def _merge_activated_skill_update(self, result: Any, slug: str, runtime_context: Any = None):
         """合并动态激活的 skill 更新"""
         from langchain_core.messages import ToolMessage
+
+        # 如果是子代理配置，直接存入 runtime_context，不污染 state
+        if self.static_skills is not None and runtime_context is not None:
+            current = getattr(runtime_context, "_subagent_activated_skills", None)
+            if current is None:
+                current = []
+                setattr(runtime_context, "_subagent_activated_skills", current)
+            if slug not in current:
+                current.append(slug)
+            return result
 
         if isinstance(result, Command):
             update = dict(result.update or {})

--- a/backend/package/yuxi/repositories/subagent_repository.py
+++ b/backend/package/yuxi/repositories/subagent_repository.py
@@ -49,6 +49,8 @@ class SubAgentRepository:
         description: str,
         system_prompt: str,
         tools: list[str] | None,
+        mcps: list[str] | None = None,
+        skills: list[str] | None = None,
         model: str | None,
         is_builtin: bool,
         created_by: str | None,
@@ -59,6 +61,8 @@ class SubAgentRepository:
             description=description,
             system_prompt=system_prompt,
             tools=tools or [],
+            mcps=mcps or [],
+            skills=skills or [],
             model=model,
             enabled=True,
             is_builtin=is_builtin,
@@ -79,6 +83,8 @@ class SubAgentRepository:
         description: str | None,
         system_prompt: str | None,
         tools: list[str] | None,
+        mcps: list[str] | None = None,
+        skills: list[str] | None = None,
         model: str | None,
         model_provided: bool = False,
         updated_by: str | None,
@@ -88,6 +94,8 @@ class SubAgentRepository:
             "description": description,
             "system_prompt": system_prompt,
             "tools": tools,
+            "mcps": mcps,
+            "skills": skills,
         }
         for field, value in updates.items():
             if value is not None:

--- a/backend/package/yuxi/services/subagent_service.py
+++ b/backend/package/yuxi/services/subagent_service.py
@@ -1,19 +1,27 @@
 """SubAgent 服务层"""
 
-import asyncio
+import json
+import time
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from yuxi.repositories.subagent_repository import SubAgentRepository
+from yuxi.services.run_queue_service import get_redis_client
 from yuxi.storage.postgres.manager import pg_manager
 from yuxi.utils import logger
 from yuxi.utils.paths import OUTPUTS_DIR_NAME
 
-# SubAgent specs cache for get_subagent_specs
-_subagent_specs_cache: list[dict[str, Any]] | None = None
-_subagent_specs_lock = asyncio.Lock()
+# ----------------------------------------------------
+# SubAgent 双级缓存控制变量
+# ----------------------------------------------------
+_REDIS_SPECS_KEY = "yuxi:subagent_cache:specs"
+_REDIS_KEY_TTL = 3600  # 1小时全局 Redis 缓存
+
+_local_specs_cache: list[dict[str, Any]] | None = None
+_local_specs_cache_at: float = 0.0
+_L2_CACHE_TTL_SECONDS = 5.0  # L2 进程级缓存生存时间 5 秒
 
 
 @asynccontextmanager
@@ -38,6 +46,8 @@ _DEFAULT_SUBAGENTS = [
             f"将调研结果保存到主题研究文件中 {OUTPUTS_DIR_NAME}/sub_research/xxx.md 中。"
         ),
         "tools": ["tavily_search"],
+        "mcps": [],
+        "skills": [],
         "is_builtin": True,
     },
     {
@@ -60,11 +70,13 @@ _DEFAULT_SUBAGENTS = [
             "- 检查文章是否结构清晰、语言流畅、易于理解。"
         ),
         "tools": [],
+        "mcps": [],
+        "skills": [],
         "is_builtin": True,
     },
 ]
 
-_SYNCED_SUBAGENT_FIELDS = ("description", "system_prompt", "tools", "model", "is_builtin")
+_SYNCED_SUBAGENT_FIELDS = ("description", "system_prompt", "tools", "mcps", "skills", "model", "is_builtin")
 
 
 async def init_builtin_subagents() -> None:
@@ -79,6 +91,8 @@ async def init_builtin_subagents() -> None:
                     description=data["description"],
                     system_prompt=data["system_prompt"],
                     tools=data.get("tools", []),
+                    mcps=data.get("mcps", []),
+                    skills=data.get("skills", []),
                     model=None,
                     is_builtin=data.get("is_builtin", False),
                     created_by="system",
@@ -95,31 +109,68 @@ async def init_builtin_subagents() -> None:
             if changed:
                 item.updated_by = "system"
         await session.commit()
-    clear_specs_cache()
+    await clear_specs_cache()
+
+
+async def clear_specs_cache() -> None:
+    """清除全局子智能体规格缓存（包括当前进程 L2 内存缓存与分布式 Redis 缓存）"""
+    global _local_specs_cache, _local_specs_cache_at
+    # 1. 废弃当前进程本地 L2 缓存
+    _local_specs_cache = None
+    _local_specs_cache_at = 0.0
+
+    # 2. 异步删除全局 Redis L1 缓存
+    try:
+        redis = await get_redis_client()
+        await redis.delete(_REDIS_SPECS_KEY)
+        logger.debug("SubAgent specs cache invalidated in Redis")
+    except Exception as e:
+        logger.warning(f"Failed to invalidate SubAgent specs cache in Redis: {e}")
 
 
 async def get_subagent_specs(db: AsyncSession | None = None) -> list[dict[str, Any]]:
-    """获取所有 subagent specs，用于 SubAgentMiddleware（工具名称未解析）"""
-    global _subagent_specs_cache
-    if _subagent_specs_cache is not None:
-        return deepcopy(_subagent_specs_cache)
-    async with _subagent_specs_lock:
-        if _subagent_specs_cache is not None:
-            return deepcopy(_subagent_specs_cache)
-        async with _get_session(db) as session:
-            repo = SubAgentRepository(session)
-            _subagent_specs_cache = await repo.list_all_specs()
-    return deepcopy(_subagent_specs_cache)
+    """获取所有已启用的 subagent specs，支持 L1 Redis + L2 本地短 TTL 内存双级缓存"""
+    global _local_specs_cache, _local_specs_cache_at
+    now = time.monotonic()
 
+    # 1. 尝试 L2 本地内存缓存命中
+    if _local_specs_cache is not None and (now - _local_specs_cache_at) < _L2_CACHE_TTL_SECONDS:
+        return deepcopy(_local_specs_cache)
 
-def clear_specs_cache() -> None:
-    """清除 subagent specs 缓存"""
-    global _subagent_specs_cache
-    _subagent_specs_cache = None
+    # 2. 尝试 L1 Redis 缓存命中
+    try:
+        redis = await get_redis_client()
+        raw = await redis.get(_REDIS_SPECS_KEY)
+        if raw:
+            specs = json.loads(raw)
+            _local_specs_cache = specs
+            _local_specs_cache_at = now
+            logger.debug("SubAgent specs loaded from Redis L1 cache")
+            return deepcopy(specs)
+    except Exception as e:
+        logger.warning(f"Failed to load SubAgent specs from Redis cache (falling back to DB): {e}")
+
+    # 3. 缓存均未命中，回退到数据库查询
+    async with _get_session(db) as session:
+        repo = SubAgentRepository(session)
+        specs = await repo.list_all_specs()
+
+    # 4. 异步回写 Redis，同步更新 L2
+    _local_specs_cache = specs
+    _local_specs_cache_at = now
+
+    try:
+        redis = await get_redis_client()
+        await redis.setex(_REDIS_SPECS_KEY, _REDIS_KEY_TTL, json.dumps(specs, ensure_ascii=False))
+        logger.debug("SubAgent specs cache populated to Redis L1")
+    except Exception as e:
+        logger.warning(f"Failed to populate SubAgent specs cache to Redis: {e}")
+
+    return deepcopy(specs)
 
 
 async def get_subagents_from_names(selected_names: Any, *, db: AsyncSession | None = None) -> list[dict[str, Any]]:
-    """根据名称获取 subagent specs（含工具解析）。"""
+    """根据名称获取 subagent specs（含工具解析 + MCP 工具异步解析）。"""
     specs = await get_subagent_specs(db)
 
     if not selected_names:
@@ -133,17 +184,46 @@ async def get_subagents_from_names(selected_names: Any, *, db: AsyncSession | No
     if missing:
         logger.warning(f"Configured subagents not found, skip: {missing}")
 
-    # 处理工具
-    # 仅从子智能体配置中的工具名称进行解析；不做 Tavily/MCP 特殊注入。
     from yuxi.agents.toolkits import get_all_tool_instances
+    from yuxi.services.mcp_service import get_enabled_mcp_tools
 
     all_tools = get_all_tool_instances()
     all_tool_names = {tool.name: tool for tool in all_tools}
     resolved_specs = []
     for spec in matched:
         resolved_spec = dict(spec)
+
+        # 1. 解析普通工具
         tool_names = spec.get("tools", [])
-        resolved_spec["tools"] = [all_tool_names[name] for name in tool_names if name in all_tool_names]
+        resolved_tools = [all_tool_names[name] for name in tool_names if name in all_tool_names]
+
+        # 2. 异步解析 MCP 工具并合并
+        mcp_names = spec.get("mcps", [])
+        mcp_tools = []
+        for server_name in mcp_names:
+            if not isinstance(server_name, str):
+                continue
+            try:
+                tools = await get_enabled_mcp_tools(server_name)
+                mcp_tools.extend(tools)
+            except Exception as e:
+                logger.warning(f"SubAgent '{spec['name']}': failed to load MCP '{server_name}': {e}")
+        resolved_tools.extend(mcp_tools)
+
+        # 3. 传递 skills 配置并构建 middleware
+        resolved_spec["skills"] = spec.get("skills", [])
+        if resolved_spec["skills"]:
+            resolved_spec["middleware"] = _build_subagent_skills_middleware(
+                resolved_spec["skills"], system_prompt=spec.get("system_prompt")
+            )
+
+            # 4. 异步解析技能（Skills）依赖的普通工具和 MCP 工具，并在 Graph 编译期并入 resolved_tools
+            dep_tools = await _resolve_skill_dependencies(resolved_spec["skills"], all_tool_names, spec["name"])
+            for t in dep_tools:
+                if t not in resolved_tools:
+                    resolved_tools.append(t)
+
+        resolved_spec["tools"] = resolved_tools
         resolved_specs.append(resolved_spec)
 
     return resolved_specs
@@ -171,6 +251,7 @@ async def create_subagent(
     db: AsyncSession | None = None,
 ) -> dict[str, Any]:
     """创建 SubAgent"""
+    await _validate_subagent_capabilities(data, db)
     async with _get_session(db) as session:
         repo = SubAgentRepository(session)
         item = await repo.create(
@@ -178,11 +259,13 @@ async def create_subagent(
             description=data["description"],
             system_prompt=data["system_prompt"],
             tools=data.get("tools"),
+            mcps=data.get("mcps"),
+            skills=data.get("skills"),
             model=data.get("model"),
             is_builtin=False,
             created_by=created_by,
         )
-    clear_specs_cache()
+    await clear_specs_cache()
     return item.to_dict()
 
 
@@ -193,6 +276,7 @@ async def update_subagent(
     db: AsyncSession | None = None,
 ) -> dict[str, Any] | None:
     """更新 SubAgent"""
+    await _validate_subagent_capabilities(data, db)
     async with _get_session(db) as session:
         repo = SubAgentRepository(session)
         item = await repo.get_by_name(name)
@@ -205,11 +289,13 @@ async def update_subagent(
             description=data.get("description"),
             system_prompt=data.get("system_prompt"),
             tools=data.get("tools"),
+            mcps=data.get("mcps"),
+            skills=data.get("skills"),
             model=data.get("model"),
             model_provided="model" in data,
             updated_by=updated_by,
         )
-    clear_specs_cache()
+    await clear_specs_cache()
     return item.to_dict()
 
 
@@ -223,7 +309,7 @@ async def delete_subagent(name: str, db: AsyncSession | None = None) -> bool:
         if item.is_builtin:
             raise ValueError("内置 SubAgent 不可删除")
         await repo.delete(item)
-    clear_specs_cache()
+    await clear_specs_cache()
     return True
 
 
@@ -244,5 +330,91 @@ async def set_subagent_enabled(
         item.updated_by = updated_by
         await session.commit()
         await session.refresh(item)
-    clear_specs_cache()
+    await clear_specs_cache()
     return item.to_dict()
+
+
+async def _resolve_skill_dependencies(
+    skills: list[str],
+    all_tool_names: dict[str, Any],
+    subagent_name: str,
+) -> list[Any]:
+    """解析技能（Skills）依赖的普通工具和 MCP 工具。"""
+    from yuxi.agents.middlewares.skills_middleware import expand_skill_closure, get_dependency_map
+    from yuxi.services.mcp_service import get_enabled_mcp_tools
+
+    resolved_dep_tools = []
+    try:
+        dependency_map = await get_dependency_map()
+        visible_skills = expand_skill_closure(skills, dependency_map)
+
+        dep_tool_names = []
+        dep_mcp_names = []
+        for s_slug in visible_skills:
+            node = dependency_map.get(s_slug)
+            if node:
+                dep_tool_names.extend(node.get("tools", []))
+                dep_mcp_names.extend(node.get("mcps", []))
+
+        # 去重
+        dep_tool_names = list(dict.fromkeys(dep_tool_names))
+        dep_mcp_names = list(dict.fromkeys(dep_mcp_names))
+
+        # 合并依赖的普通工具到 resolved_dep_tools
+        for t_name in dep_tool_names:
+            if t_name in all_tool_names:
+                resolved_dep_tools.append(all_tool_names[t_name])
+
+        # 合并依赖的 MCP 工具到 resolved_dep_tools
+        for server_name in dep_mcp_names:
+            if not isinstance(server_name, str):
+                continue
+            try:
+                tools = await get_enabled_mcp_tools(server_name)
+                for t in tools:
+                    if t not in resolved_dep_tools:
+                        resolved_dep_tools.append(t)
+            except Exception as e:
+                logger.warning(f"SubAgent '{subagent_name}': failed to load Skill dependent MCP '{server_name}': {e}")
+    except Exception as e:
+        logger.error(f"Failed to resolve skill dependencies for subagent '{subagent_name}': {e}")
+
+    return resolved_dep_tools
+
+
+def _build_subagent_skills_middleware(skills: list[str], system_prompt: str | None = None) -> list:
+    """为有 Skills 配置的子代理构建专属 middleware 列表。"""
+    from yuxi.agents.middlewares.skills_middleware import SkillsMiddleware
+
+    return [SkillsMiddleware(static_skills=skills, subagent_system_prompt=system_prompt)]
+
+
+async def _validate_subagent_capabilities(data: dict[str, Any], db: AsyncSession | None = None) -> None:
+    """校验 SubAgent 配置的工具/MCP/Skills 是否有效"""
+    from yuxi.agents.toolkits import get_all_tool_instances
+    from yuxi.services.mcp_service import get_enabled_mcp_server_config
+    from yuxi.services.skill_service import list_skills
+
+    # 校验工具
+    if tools := data.get("tools"):
+        all_tools = get_all_tool_instances()
+        valid_names = {t.name for t in all_tools}
+        invalid = [t for t in tools if t not in valid_names]
+        if invalid:
+            raise ValueError(f"无效的工具: {invalid}")
+
+    # 校验 MCP（必须存在且已启用）
+    if mcps := data.get("mcps"):
+        for name in mcps:
+            config = await get_enabled_mcp_server_config(name)
+            if not config:
+                raise ValueError(f"MCP 服务 '{name}' 不存在或未启用")
+
+    # 校验 Skills（必须存在于 skills 表）
+    if skills := data.get("skills"):
+        async with _get_session(db) as session:
+            all_skills = await list_skills(session)
+            valid_slugs = {s.slug for s in all_skills}
+            invalid = [s for s in skills if s not in valid_slugs]
+            if invalid:
+                raise ValueError(f"无效的 Skill: {invalid}")

--- a/backend/package/yuxi/storage/postgres/manager.py
+++ b/backend/package/yuxi/storage/postgres/manager.py
@@ -194,6 +194,8 @@ class PostgresManager(metaclass=SingletonMeta):
             "ALTER TABLE IF EXISTS skills ADD COLUMN IF NOT EXISTS is_builtin BOOLEAN NOT NULL DEFAULT FALSE",
             "ALTER TABLE IF EXISTS skills ADD COLUMN IF NOT EXISTS content_hash VARCHAR(128)",
             "ALTER TABLE IF EXISTS subagents ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE",
+            "ALTER TABLE IF EXISTS subagents ADD COLUMN IF NOT EXISTS mcps JSONB DEFAULT '[]'::jsonb",
+            "ALTER TABLE IF EXISTS subagents ADD COLUMN IF NOT EXISTS skills JSONB DEFAULT '[]'::jsonb",
             "ALTER TABLE IF EXISTS conversations ADD COLUMN IF NOT EXISTS is_pinned BOOLEAN NOT NULL DEFAULT FALSE",
             "ALTER TABLE IF EXISTS mcp_servers ADD COLUMN IF NOT EXISTS env JSONB",
             """

--- a/backend/package/yuxi/storage/postgres/models_business.py
+++ b/backend/package/yuxi/storage/postgres/models_business.py
@@ -639,6 +639,8 @@ class SubAgent(Base):
     system_prompt = Column(Text, nullable=False, comment="系统提示词")
     tools = Column(JSON, nullable=False, default=list, comment="工具名称列表")
     model = Column(String(128), nullable=True, comment="可选的模型覆盖")
+    mcps = Column(JSON, nullable=False, default=list, comment="MCP 服务名列表")
+    skills = Column(JSON, nullable=False, default=list, comment="Skill slug 列表")
     enabled = Column(Boolean, nullable=False, default=True, comment="是否启用")
 
     is_builtin = Column(Boolean, nullable=False, default=False, comment="是否内置")
@@ -654,6 +656,8 @@ class SubAgent(Base):
             "description": self.description,
             "system_prompt": self.system_prompt,
             "tools": self.tools or [],
+            "mcps": self.mcps or [],
+            "skills": self.skills or [],
             "model": self.model,
             "enabled": bool(self.enabled),
             "is_builtin": bool(self.is_builtin),
@@ -670,6 +674,8 @@ class SubAgent(Base):
             "description": self.description,
             "system_prompt": self.system_prompt,
             "tools": self.tools or [],
+            "mcps": self.mcps or [],
+            "skills": self.skills or [],
         }
         if self.model:
             spec["model"] = self.model

--- a/backend/server/routers/subagent_router.py
+++ b/backend/server/routers/subagent_router.py
@@ -21,6 +21,8 @@ class SubAgentCreateRequest(BaseModel):
     description: str = Field(..., description="描述")
     system_prompt: str = Field(..., description="系统提示词")
     tools: list[str] = Field(default_factory=list, description="工具名称列表")
+    mcps: list[str] = Field(default_factory=list, description="MCP 服务名列表")
+    skills: list[str] = Field(default_factory=list, description="Skill slug 列表")
     model: str | None = Field(None, description="可选的模型覆盖")
 
 
@@ -28,6 +30,8 @@ class SubAgentUpdateRequest(BaseModel):
     description: str | None = Field(None, description="描述")
     system_prompt: str | None = Field(None, description="系统提示词")
     tools: list[str] | None = Field(None, description="工具名称列表")
+    mcps: list[str] | None = Field(None, description="MCP 服务名列表")
+    skills: list[str] | None = Field(None, description="Skill slug 列表")
     model: str | None = Field(None, description="可选的模型覆盖")
 
 

--- a/backend/test/integration/test_subagent_runtime.py
+++ b/backend/test/integration/test_subagent_runtime.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import pytest
+import httpx
+
+
+@pytest.mark.asyncio
+async def test_subagent_crud_mcps_and_skills_api(test_client: httpx.AsyncClient, admin_headers: dict[str, str]):
+    """
+    通过真实的 API 测试子代理的 CRUD 操作，验证 mcps 和 skills 字段在网络传输与数据库落库中的正确性。
+    """
+    from yuxi.storage.postgres.manager import pg_manager
+    from yuxi.storage.postgres.models_business import MCPServer, Skill
+    from sqlalchemy import delete
+
+    subagent_name = "integration-test-subagent"
+    
+    # 0. 准备测试依赖的 MCP 服务器和 Skill 并入库以通过 capability 校验
+    test_mcps = ["test-mcp-server-1", "test-mcp-server-2", "test-mcp-server-3"]
+    test_skills = ["dummy-skill-x", "dummy-skill-y", "dummy-skill-z"]
+
+    async with pg_manager.get_async_session_context() as session:
+        # 清理可能残留的脏数据，防止冲突
+        await session.execute(delete(MCPServer).where(MCPServer.name.in_(test_mcps)))
+        await session.execute(delete(Skill).where(Skill.slug.in_(test_skills)))
+        
+        # 写入 Mock MCP 服务器
+        for name in test_mcps:
+            server = MCPServer(
+                name=name,
+                transport="stdio",
+                command="echo",
+                enabled=1,
+                created_by="system",
+                updated_by="system",
+            )
+            session.add(server)
+            
+        # 写入 Mock Skills
+        for slug in test_skills:
+            skill = Skill(
+                slug=slug,
+                name=f"Mock {slug}",
+                description="Mock Skill for integration test",
+                dir_path=f"mock_skills/{slug}",
+                tool_dependencies=[],
+                mcp_dependencies=[],
+                skill_dependencies=[],
+                created_by="system",
+                updated_by="system",
+            )
+            session.add(skill)
+        await session.commit()
+
+    try:
+        # 1. 创建子代理
+        create_payload = {
+            "name": subagent_name,
+            "description": "Integration test description",
+            "system_prompt": "Integration test prompt",
+            "tools": ["calculator"],  # 使用真实存在的内置工具
+            "mcps": ["test-mcp-server-1", "test-mcp-server-2"],
+            "skills": ["dummy-skill-x", "dummy-skill-y"],
+            "model": None,
+        }
+        
+        # 清理已存在的同名子代理，防止干扰
+        await test_client.delete(f"/api/system/subagents/{subagent_name}", headers=admin_headers)
+
+        create_response = await test_client.post(
+            "/api/system/subagents",
+            json=create_payload,
+            headers=admin_headers,
+        )
+        
+        assert create_response.status_code == 200, f"创建子代理失败: {create_response.text}"
+        created_data = create_response.json().get("data", {})
+        assert created_data["name"] == subagent_name
+        assert created_data["mcps"] == ["test-mcp-server-1", "test-mcp-server-2"]
+        assert created_data["skills"] == ["dummy-skill-x", "dummy-skill-y"]
+        assert created_data["tools"] == ["calculator"]
+
+        # 2. 查询单个子代理详情
+        get_response = await test_client.get(
+            f"/api/system/subagents/{subagent_name}",
+            headers=admin_headers,
+        )
+        assert get_response.status_code == 200, f"获取子代理失败: {get_response.text}"
+        fetched_data = get_response.json().get("data", {})
+        assert fetched_data["name"] == subagent_name
+        assert fetched_data["mcps"] == ["test-mcp-server-1", "test-mcp-server-2"]
+        assert fetched_data["skills"] == ["dummy-skill-x", "dummy-skill-y"]
+
+        # 3. 更新子代理的 mcps 和 skills
+        update_payload = {
+            "name": subagent_name,
+            "description": "Integration test description updated",
+            "system_prompt": "Integration test prompt updated",
+            "tools": [],
+            "mcps": ["test-mcp-server-3"],
+            "skills": ["dummy-skill-z"],
+            "model": None,
+        }
+        
+        update_response = await test_client.put(
+            f"/api/system/subagents/{subagent_name}",
+            json=update_payload,
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200, f"更新子代理失败: {update_response.text}"
+        
+        # 再次查询验证更新是否成功落库
+        get_again_response = await test_client.get(
+            f"/api/system/subagents/{subagent_name}",
+            headers=admin_headers,
+        )
+        assert get_again_response.status_code == 200
+        updated_fetched_data = get_again_response.json().get("data", {})
+        assert updated_fetched_data["description"] == "Integration test description updated"
+        assert updated_fetched_data["mcps"] == ["test-mcp-server-3"]
+        assert updated_fetched_data["skills"] == ["dummy-skill-z"]
+
+        # 4. 删除子代理
+        delete_response = await test_client.delete(
+            f"/api/system/subagents/{subagent_name}",
+            headers=admin_headers,
+        )
+        assert delete_response.status_code == 200, f"删除子代理失败: {delete_response.text}"
+
+        # 验证已被删除
+        get_after_delete = await test_client.get(
+            f"/api/system/subagents/{subagent_name}",
+            headers=admin_headers,
+        )
+        assert get_after_delete.status_code == 404
+
+    finally:
+        # 清理数据库中的 Mock 依赖
+        async with pg_manager.get_async_session_context() as session:
+            await session.execute(delete(MCPServer).where(MCPServer.name.in_(test_mcps)))
+            await session.execute(delete(Skill).where(Skill.slug.in_(test_skills)))
+            await session.commit()

--- a/backend/test/unit/services/test_subagent_mcps_skills.py
+++ b/backend/test/unit/services/test_subagent_mcps_skills.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from yuxi.services import subagent_service
+from yuxi.agents.middlewares.skills_middleware import SkillsMiddleware, SkillsState
+
+
+@pytest.mark.asyncio
+async def test_get_subagents_from_names_mcps_and_skills(monkeypatch):
+    """
+    测试根据名称获取子代理规格时，能够正确解析普通工具、MCP工具并注入绑定 static_skills 的 SkillsMiddleware。
+    """
+    # 1. 模拟 get_subagent_specs 返回含有 mcps 和 skills 的子代理定义
+    fake_subagent_spec = {
+        "name": "mcp_skill_subagent",
+        "description": "A subagent designed to test mcp and skills binding",
+        "system_prompt": "You are a test subagent.",
+        "tools": ["dummy_standard_tool"],
+        "mcps": ["test_mcp_server"],
+        "skills": ["dummy-skill-a", "dummy-skill-b"],
+        "model": None,
+        "is_builtin": False,
+    }
+    
+    async def mock_get_subagent_specs(db=None):
+        return [fake_subagent_spec]
+
+    monkeypatch.setattr(
+        subagent_service,
+        "get_subagent_specs",
+        mock_get_subagent_specs,
+    )
+
+    # 2. 模拟 get_all_tool_instances 返回标准普通工具
+    fake_standard_tool = SimpleNamespace(
+        name="dummy_standard_tool",
+        description="A standard tool",
+    )
+    fake_dep_tool = SimpleNamespace(
+        name="dummy_dep_tool",
+        description="A skill dependency tool",
+    )
+    monkeypatch.setattr(
+        "yuxi.agents.toolkits.get_all_tool_instances",
+        lambda: [fake_standard_tool, fake_dep_tool],
+    )
+
+    # 3. 模拟 get_enabled_mcp_tools 返回 MCP 工具
+    fake_mcp_tool = SimpleNamespace(
+        name="dummy_mcp_tool",
+        description="An MCP tool",
+    )
+    fake_dep_mcp_tool = SimpleNamespace(
+        name="dummy_dep_mcp_tool",
+        description="A dependency MCP tool",
+    )
+    async def mock_get_mcp_tools(server_name):
+        if server_name == "test_mcp_server":
+            return [fake_mcp_tool]
+        elif server_name == "dummy_dep_mcp_server":
+            return [fake_dep_mcp_tool]
+        return []
+
+    monkeypatch.setattr(
+        "yuxi.services.mcp_service.get_enabled_mcp_tools",
+        mock_get_mcp_tools,
+    )
+
+    # 4. Mock 技能依赖关系数据
+    async def mock_get_dependency_map(db=None):
+        return {
+            "dummy-skill-a": {
+                "tools": ["dummy_dep_tool"],
+                "mcps": ["dummy_dep_mcp_server"],
+                "skills": []
+            },
+            "dummy-skill-b": {
+                "tools": [],
+                "mcps": [],
+                "skills": []
+            }
+        }
+
+    def mock_expand_skill_closure(slugs, dependency_map):
+        return slugs
+
+    monkeypatch.setattr(
+        "yuxi.agents.middlewares.skills_middleware.get_dependency_map",
+        mock_get_dependency_map,
+    )
+    monkeypatch.setattr(
+        "yuxi.agents.middlewares.skills_middleware.expand_skill_closure",
+        mock_expand_skill_closure,
+    )
+
+    # 5. 执行获取子代理的逻辑
+    resolved_specs = await subagent_service.get_subagents_from_names(["mcp_skill_subagent"])
+
+    # 6. 断言验证
+    assert len(resolved_specs) == 1
+    spec = resolved_specs[0]
+    
+    assert spec["name"] == "mcp_skill_subagent"
+    
+    # 验证工具包含自身配置工具、自身 MCP 工具，以及技能依赖展开的工具和 MCP 工具
+    tool_names = [t.name for t in spec["tools"]]
+    assert "dummy_standard_tool" in tool_names
+    assert "dummy_mcp_tool" in tool_names
+    assert "dummy_dep_tool" in tool_names
+    assert "dummy_dep_mcp_tool" in tool_names
+    assert len(tool_names) == 4
+    
+    # 验证 SkillsMiddleware 的注入与 static_skills 绑定
+    assert "middleware" in spec
+    assert len(spec["middleware"]) == 1
+    middleware = spec["middleware"][0]
+    assert isinstance(middleware, SkillsMiddleware)
+    assert middleware.static_skills == ["dummy-skill-a", "dummy-skill-b"]
+
+
+
+@pytest.mark.asyncio
+async def test_subagent_specs_cache_miss_and_populate(monkeypatch):
+    """测试缓存未命中时能够查询 DB 并成功填充回写 Redis。"""
+    from yuxi.services import subagent_service
+    
+    # 强制清空缓存状态
+    monkeypatch.setattr(subagent_service, "_local_specs_cache", None)
+    monkeypatch.setattr(subagent_service, "_local_specs_cache_at", 0.0)
+
+    # 1. 模拟 DB
+    mock_specs = [{"name": "db-subagent", "tools": []}]
+    async def mock_list_all_specs(db=None):
+        return mock_specs
+    
+    class MockRepo:
+        def __init__(self, session): pass
+        async def list_all_specs(self):
+            return mock_specs
+
+    monkeypatch.setattr(subagent_service, "SubAgentRepository", MockRepo)
+
+    # 2. Mock Redis
+    class MockRedis:
+        def __init__(self):
+            self.store = {}
+        async def get(self, key):
+            return self.store.get(key)
+        async def setex(self, key, ttl, value):
+            self.store[key] = value
+
+    mock_redis = MockRedis()
+    async def mock_get_redis_client():
+        return mock_redis
+
+    monkeypatch.setattr(subagent_service, "get_redis_client", mock_get_redis_client)
+
+    # 3. 运行测试
+    specs = await subagent_service.get_subagent_specs()
+    assert specs == mock_specs
+
+    # 4. 验证 Redis 确实被填充写入了
+    import json
+    cached = await mock_redis.get(subagent_service._REDIS_SPECS_KEY)
+    assert cached is not None
+    assert json.loads(cached) == mock_specs
+
+
+@pytest.mark.asyncio
+async def test_subagent_specs_l2_cache_hit(monkeypatch):
+    """测试本地二级缓存（L2 Cache）在 TTL 周期内能够直接命中，避免多余 Redis/DB 查询。"""
+    from yuxi.services import subagent_service
+    
+    # 1. 直接强行预先填充 L2 内存缓存
+    mock_l2_specs = [{"name": "l2-cached-subagent", "tools": []}]
+    import time
+    monkeypatch.setattr(subagent_service, "_local_specs_cache", mock_l2_specs)
+    monkeypatch.setattr(subagent_service, "_local_specs_cache_at", time.monotonic())
+
+    # 2. 模拟 DB 和 Redis 抛出异常（确保它们绝对不被访问）
+    async def mock_get_redis_client():
+        raise RuntimeError("Should not access Redis!")
+    
+    class ErrorRepo:
+        def __init__(self, session): pass
+        async def list_all_specs(self):
+            raise RuntimeError("Should not access DB!")
+
+    monkeypatch.setattr(subagent_service, "get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(subagent_service, "SubAgentRepository", ErrorRepo)
+
+    # 3. 运行测试并验证命中返回
+    specs = await subagent_service.get_subagent_specs()
+    assert specs == mock_l2_specs
+
+
+@pytest.mark.asyncio
+async def test_subagent_specs_eviction(monkeypatch):
+    """测试调用 clear_specs_cache 时，能正确清空本地 L2 缓存并向 Redis 发送删除信号。"""
+    from yuxi.services import subagent_service
+    
+    # 1. 预设 L2 缓存
+    monkeypatch.setattr(subagent_service, "_local_specs_cache", [{"name": "dummy"}])
+    monkeypatch.setattr(subagent_service, "_local_specs_cache_at", 12345.6)
+
+    # 2. Mock Redis delete
+    deleted_keys = []
+    class MockRedis:
+        async def delete(self, key):
+            deleted_keys.append(key)
+
+    mock_redis = MockRedis()
+    async def mock_get_redis_client():
+        return mock_redis
+
+    monkeypatch.setattr(subagent_service, "get_redis_client", mock_get_redis_client)
+
+    # 3. 触发清理
+    await subagent_service.clear_specs_cache()
+
+    # 4. 验证本地 L2 和 Redis 都已被清除
+    assert subagent_service._local_specs_cache is None
+    assert subagent_service._local_specs_cache_at == 0.0
+    assert subagent_service._REDIS_SPECS_KEY in deleted_keys
+
+
+@pytest.mark.asyncio
+async def test_subagent_specs_fallback_on_redis_error(monkeypatch):
+    """测试 Redis 连接引发异常时，能无缝优雅退化降级到直接查询数据库，保障高可用。"""
+    from yuxi.services import subagent_service
+    
+    # 强制清理 L2
+    monkeypatch.setattr(subagent_service, "_local_specs_cache", None)
+    monkeypatch.setattr(subagent_service, "_local_specs_cache_at", 0.0)
+
+    # 1. Mock DB 提供数据
+    mock_db_specs = [{"name": "fallback-subagent", "tools": []}]
+    class MockRepo:
+        def __init__(self, session): pass
+        async def list_all_specs(self):
+            return mock_db_specs
+
+    monkeypatch.setattr(subagent_service, "SubAgentRepository", MockRepo)
+
+    # 2. Mock Redis 产生连接异常
+    async def mock_broken_redis_client():
+        raise ConnectionError("Redis connection refused!")
+
+    monkeypatch.setattr(subagent_service, "get_redis_client", mock_broken_redis_client)
+
+    # 3. 运行测试，验证依然返回 DB 数据而不受 Redis 挂掉影响
+    specs = await subagent_service.get_subagent_specs()
+    assert specs == mock_db_specs
+

--- a/web/src/components/extensions/SubagentCardList.vue
+++ b/web/src/components/extensions/SubagentCardList.vue
@@ -83,6 +83,26 @@
             @focus="fetchAvailableTools"
           />
         </a-form-item>
+        <a-form-item label="MCP服务器" class="form-item">
+          <a-select
+            v-model:value="form.mcps"
+            mode="tags"
+            placeholder="选择或输入启用子代理专属 MCP 服务器"
+            style="width: 100%"
+            :options="availableMcps"
+            @focus="fetchAvailableMcps"
+          />
+        </a-form-item>
+        <a-form-item label="技能（Skills）" class="form-item">
+          <a-select
+            v-model:value="form.skills"
+            mode="tags"
+            placeholder="选择或输入子代理专属技能"
+            style="width: 100%"
+            :options="availableSkills"
+            @focus="fetchAvailableSkills"
+          />
+        </a-form-item>
         <a-form-item label="模型覆盖（可选）" class="form-item">
           <div class="model-override-row">
             <ModelSelectorComponent
@@ -107,7 +127,7 @@ import { useRouter } from 'vue-router'
 import { message } from 'ant-design-vue'
 import { Plus, RefreshCw, Bot } from 'lucide-vue-next'
 import { subagentApi } from '@/apis/subagent_api'
-import { toolApi } from '@/apis/tool_api'
+import { useSubagentOptions } from '@/composables/useSubagentOptions'
 import ExtensionCardGrid from './ExtensionCardGrid.vue'
 import InfoCard from '@/components/shared/InfoCard.vue'
 import PageShoulder from '@/components/shared/PageShoulder.vue'
@@ -120,7 +140,15 @@ const router = useRouter()
 const loading = ref(false)
 const subagents = ref([])
 const searchQuery = ref('')
-const availableTools = ref([])
+
+const {
+  availableTools,
+  availableMcps,
+  availableSkills,
+  fetchAvailableTools,
+  fetchAvailableMcps,
+  fetchAvailableSkills
+} = useSubagentOptions()
 
 const formModalVisible = ref(false)
 const formLoading = ref(false)
@@ -129,6 +157,8 @@ const form = reactive({
   description: '',
   system_prompt: '',
   tools: [],
+  mcps: [],
+  skills: [],
   model: ''
 })
 
@@ -160,20 +190,16 @@ const navigateToDetail = (agent) => {
 }
 
 const handleSubagentAdd = () => {
-  Object.assign(form, { name: '', description: '', system_prompt: '', tools: [], model: '' })
+  Object.assign(form, {
+    name: '',
+    description: '',
+    system_prompt: '',
+    tools: [],
+    mcps: [],
+    skills: [],
+    model: ''
+  })
   formModalVisible.value = true
-}
-
-const fetchAvailableTools = async () => {
-  if (availableTools.value.length > 0) return
-  try {
-    const result = await toolApi.getToolOptions()
-    if (result.success && result.data) {
-      availableTools.value = result.data
-    }
-  } catch (err) {
-    console.error('获取工具选项失败:', err)
-  }
 }
 
 const handleModelSelect = (spec) => {
@@ -196,6 +222,8 @@ const handleFormSubmit = async () => {
       description: form.description || '',
       system_prompt: form.system_prompt,
       tools: form.tools || [],
+      mcps: form.mcps || [],
+      skills: form.skills || [],
       model: form.model || null
     }
     const result = await subagentApi.createSubAgent(data)

--- a/web/src/components/extensions/SubagentDetailView.vue
+++ b/web/src/components/extensions/SubagentDetailView.vue
@@ -89,6 +89,26 @@
               </div>
             </div>
 
+            <div class="detail-section" v-if="agent.mcps && agent.mcps.length > 0">
+              <div class="section-header">
+                <Server :size="14" />
+                <span>MCP 服务器</span>
+              </div>
+              <div class="section-content">
+                <a-tag v-for="mcp in agent.mcps" :key="mcp" color="blue">{{ mcp }}</a-tag>
+              </div>
+            </div>
+
+            <div class="detail-section" v-if="agent.skills && agent.skills.length > 0">
+              <div class="section-header">
+                <Sparkles :size="14" />
+                <span>技能 (Skills)</span>
+              </div>
+              <div class="section-content">
+                <a-tag v-for="skill in agent.skills" :key="skill" color="purple">{{ skill }}</a-tag>
+              </div>
+            </div>
+
             <div class="detail-section" v-if="agent.is_builtin || agent.enabled === false">
               <div class="section-header">
                 <Info :size="14" />
@@ -162,6 +182,26 @@
             @focus="fetchAvailableTools"
           />
         </a-form-item>
+        <a-form-item label="MCP服务器" class="form-item">
+          <a-select
+            v-model:value="form.mcps"
+            mode="tags"
+            placeholder="选择或输入启用子代理专属 MCP 服务器"
+            style="width: 100%"
+            :options="availableMcps"
+            @focus="fetchAvailableMcps"
+          />
+        </a-form-item>
+        <a-form-item label="技能（Skills）" class="form-item">
+          <a-select
+            v-model:value="form.skills"
+            mode="tags"
+            placeholder="选择或输入子代理专属技能"
+            style="width: 100%"
+            :options="availableSkills"
+            @focus="fetchAvailableSkills"
+          />
+        </a-form-item>
         <a-form-item label="模型覆盖（可选）" class="form-item">
           <div class="model-override-row">
             <ModelSelectorComponent
@@ -194,10 +234,12 @@ import {
   FileText,
   Cpu,
   Wrench,
-  Clock
+  Clock,
+  Server,
+  Sparkles
 } from 'lucide-vue-next'
 import { subagentApi } from '@/apis/subagent_api'
-import { toolApi } from '@/apis/tool_api'
+import { useSubagentOptions } from '@/composables/useSubagentOptions'
 import { formatFullDateTime } from '@/utils/time'
 import ModelSelectorComponent from '@/components/ModelSelectorComponent.vue'
 
@@ -210,12 +252,22 @@ const agent = ref(null)
 
 const formModalVisible = ref(false)
 const formLoading = ref(false)
-const availableTools = ref([])
+
+const {
+  availableTools,
+  availableMcps,
+  availableSkills,
+  fetchAvailableTools,
+  fetchAvailableMcps,
+  fetchAvailableSkills
+} = useSubagentOptions()
 const form = reactive({
   name: '',
   description: '',
   system_prompt: '',
   tools: [],
+  mcps: [],
+  skills: [],
   model: ''
 })
 
@@ -241,18 +293,6 @@ const fetchAgent = async () => {
   }
 }
 
-const fetchAvailableTools = async () => {
-  if (availableTools.value.length > 0) return
-  try {
-    const result = await toolApi.getToolOptions()
-    if (result.success && result.data) {
-      availableTools.value = result.data
-    }
-  } catch (err) {
-    console.error('获取工具选项失败:', err)
-  }
-}
-
 const showEditModal = () => {
   if (!agent.value) return
   Object.assign(form, {
@@ -260,6 +300,8 @@ const showEditModal = () => {
     description: agent.value.description || '',
     system_prompt: agent.value.system_prompt || '',
     tools: agent.value.tools || [],
+    mcps: agent.value.mcps || [],
+    skills: agent.value.skills || [],
     model: agent.value.model || ''
   })
   formModalVisible.value = true
@@ -281,6 +323,8 @@ const handleFormSubmit = async () => {
       description: form.description || '',
       system_prompt: form.system_prompt,
       tools: form.tools || [],
+      mcps: form.mcps || [],
+      skills: form.skills || [],
       model: form.model || null
     }
     const result = await subagentApi.updateSubAgent(form.name, data)

--- a/web/src/composables/useSubagentOptions.js
+++ b/web/src/composables/useSubagentOptions.js
@@ -1,0 +1,63 @@
+import { ref } from 'vue'
+import { toolApi } from '@/apis/tool_api'
+import { mcpApi } from '@/apis/mcp_api'
+import { skillApi } from '@/apis/skill_api'
+
+export function useSubagentOptions() {
+  const availableTools = ref([])
+  const availableMcps = ref([])
+  const availableSkills = ref([])
+
+  const fetchAvailableTools = async () => {
+    if (availableTools.value.length > 0) return
+    try {
+      const result = await toolApi.getToolOptions()
+      if (result.success && result.data) {
+        availableTools.value = result.data
+      }
+    } catch (err) {
+      console.error('获取工具选项失败:', err)
+    }
+  }
+
+  const fetchAvailableMcps = async () => {
+    if (availableMcps.value.length > 0) return
+    try {
+      const result = await mcpApi.getMcpServers()
+      if (result.success && result.data) {
+        availableMcps.value = result.data
+          .filter((item) => item?.enabled !== false)
+          .map((item) => ({
+            label: item.name,
+            value: item.name
+          }))
+      }
+    } catch (err) {
+      console.error('获取 MCP 选项失败:', err)
+    }
+  }
+
+  const fetchAvailableSkills = async () => {
+    if (availableSkills.value.length > 0) return
+    try {
+      const result = await skillApi.listSkills()
+      if (result.success && result.data) {
+        availableSkills.value = result.data.map((item) => ({
+          label: item.slug,
+          value: item.slug
+        }))
+      }
+    } catch (err) {
+      console.error('获取 Skills 选项失败:', err)
+    }
+  }
+
+  return {
+    availableTools,
+    availableMcps,
+    availableSkills,
+    fetchAvailableTools,
+    fetchAvailableMcps,
+    fetchAvailableSkills
+  }
+}


### PR DESCRIPTION
## 变更描述
简要描述这个 PR 做了什么

- 子代理支持 MCP 和 Skills 独立配置及状态隔离

## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

<img width="1440" height="820" alt="image" src="https://github.com/user-attachments/assets/e0cf42ff-2b9b-4bcd-bf15-af0bb8ad2537" />


## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范