### PR TITLE
fix(knowledge): 支持白名单内网 URL 抓取

### DIFF
--- a/backend/package/yuxi/knowledge/utils/url_fetcher.py
+++ b/backend/package/yuxi/knowledge/utils/url_fetcher.py
@@ -13,8 +13,8 @@ MAX_DOWNLOAD_SIZE = 10 * 1024 * 1024
 ALLOWED_CONTENT_TYPES = ["text/html", "application/xhtml+xml"]
 
 
-async def is_private_ip(hostname: str) -> bool:
-    """Check if the hostname resolves to a private IP address."""
+async def is_forbidden_ip(hostname: str) -> bool:
+    """Check if the hostname resolves to a forbidden IP address."""
     import asyncio
 
     try:
@@ -23,7 +23,7 @@ async def is_private_ip(hostname: str) -> bool:
         for item in ip_list:
             ip_addr = item[4][0]
             ip_obj = ipaddress.ip_address(ip_addr)
-            if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+            if ip_obj.is_loopback or ip_obj.is_link_local:
                 return True
         return False
     except Exception as e:
@@ -36,7 +36,7 @@ async def is_private_ip(hostname: str) -> bool:
 
 async def fetch_url_content(url: str, max_size: int = MAX_DOWNLOAD_SIZE) -> tuple[bytes, str]:
     """
-    Fetch URL content with security checks (size limit, content type, private IP blocking).
+    Fetch URL content with security checks (size limit, content type, loopback/link-local blocking).
 
     Args:
         url: The URL to fetch.
@@ -58,8 +58,11 @@ async def fetch_url_content(url: str, max_size: int = MAX_DOWNLOAD_SIZE) -> tupl
 
     # Parse URL to check IP
     parsed_url = urlparse(url)
-    if await is_private_ip(parsed_url.hostname):
-        raise ValueError("Access to private IP addresses is forbidden")
+    hostname = parsed_url.hostname
+    if hostname is None:
+        raise ValueError("Invalid URL: no hostname found")
+    if await is_forbidden_ip(hostname):
+        raise ValueError("Access to loopback or link-local IP addresses is forbidden")
 
     current_url = url
     redirect_count = 0
@@ -99,8 +102,6 @@ async def fetch_url_content(url: str, max_size: int = MAX_DOWNLOAD_SIZE) -> tupl
                             current_url = f"{parsed_current.scheme}://{parsed_current.netloc}{location}"
                         elif not location.startswith("http"):
                             # Handle relative path without /? or other weird cases, or assume absolute
-                            parsed_current = urlparse(current_url)
-                            # simple join
                             from urllib.parse import urljoin
 
                             current_url = urljoin(current_url, location)
@@ -113,8 +114,11 @@ async def fetch_url_content(url: str, max_size: int = MAX_DOWNLOAD_SIZE) -> tupl
                             raise ValueError(f"Redirected to invalid URL: {error_msg}")
 
                         parsed_new = urlparse(current_url)
-                        if await is_private_ip(parsed_new.hostname):
-                            raise ValueError("Redirected to private IP address")
+                        new_hostname = parsed_new.hostname
+                        if new_hostname is None:
+                            raise ValueError("Redirected to invalid URL: no hostname found")
+                        if await is_forbidden_ip(new_hostname):
+                            raise ValueError("Redirected to loopback or link-local IP address")
 
                         continue  # Start new request
 

--- a/backend/package/yuxi/knowledge/utils/url_fetcher.py
+++ b/backend/package/yuxi/knowledge/utils/url_fetcher.py
@@ -22,16 +22,15 @@ async def is_forbidden_ip(hostname: str) -> bool:
         ip_list = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
         for item in ip_list:
             ip_addr = item[4][0]
+            if "%" in ip_addr:
+                ip_addr = ip_addr.split("%", 1)[0]
             ip_obj = ipaddress.ip_address(ip_addr)
             if ip_obj.is_loopback or ip_obj.is_link_local:
                 return True
         return False
     except Exception as e:
         logger.warning(f"Failed to resolve hostname {hostname}: {e}")
-        # If resolution fails, assume it's unsafe or let the connection fail naturally,
-        # but to be safe we can return True to block it if strict mode is preferred.
-        # For now, we return False assuming standard DNS failure handling.
-        return False
+        return True
 
 
 async def fetch_url_content(url: str, max_size: int = MAX_DOWNLOAD_SIZE) -> tuple[bytes, str]:

--- a/backend/test/unit/knowledge/test_url_fetcher.py
+++ b/backend/test/unit/knowledge/test_url_fetcher.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from yuxi.knowledge.utils import url_fetcher
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.unit]
+
+
+async def test_forbidden_ip_allows_private_network_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        url_fetcher.socket,
+        "getaddrinfo",
+        lambda hostname, port: [(None, None, None, None, ("172.27.86.91", 0))],
+    )
+
+    assert await url_fetcher.is_forbidden_ip("172.27.86.91") is False
+
+
+@pytest.mark.parametrize("ip_addr", ["127.0.0.1", "169.254.169.254", "::1", "fe80::1"])
+async def test_forbidden_ip_blocks_loopback_and_link_local(
+    monkeypatch: pytest.MonkeyPatch, ip_addr: str
+) -> None:
+    monkeypatch.setattr(
+        url_fetcher.socket,
+        "getaddrinfo",
+        lambda hostname, port: [(None, None, None, None, (ip_addr, 0))],
+    )
+
+    assert await url_fetcher.is_forbidden_ip(ip_addr) is True
+
+
+def test_whitelist_allows_private_ip_hostname(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("YUXI_URL_WHITELIST", "alidocs.dingtalk.com,172.27.86.91")
+
+    is_valid, error_msg = url_fetcher.validate_url("http://172.27.86.91:8090/api/pages/34")
+
+    assert is_valid is True
+    assert error_msg == ""

--- a/backend/test/unit/knowledge/test_url_fetcher.py
+++ b/backend/test/unit/knowledge/test_url_fetcher.py
@@ -17,7 +17,7 @@ async def test_forbidden_ip_allows_private_network_addresses(monkeypatch: pytest
     assert await url_fetcher.is_forbidden_ip("172.27.86.91") is False
 
 
-@pytest.mark.parametrize("ip_addr", ["127.0.0.1", "169.254.169.254", "::1", "fe80::1"])
+@pytest.mark.parametrize("ip_addr", ["127.0.0.1", "169.254.169.254", "::1", "fe80::1", "fe80::1%lo0"])
 async def test_forbidden_ip_blocks_loopback_and_link_local(
     monkeypatch: pytest.MonkeyPatch, ip_addr: str
 ) -> None:

--- a/docs/advanced/document-processing.md
+++ b/docs/advanced/document-processing.md
@@ -35,7 +35,9 @@ Yuxi 支持多种文档格式的智能解析，从简单的文本文件到复杂
 3. 内置去重机制，避免重复抓取
 
 ::: tip URL 白名单配置
-示例：`YUXI_URL_WHITELIST=github.com,*.wikipedia.org,docs.python.org`
+示例：`YUXI_URL_WHITELIST=github.com,*.wikipedia.org,docs.python.org,172.27.86.91`
+
+白名单项匹配 URL 的 hostname，不包含端口。命中白名单的普通内网 IP 可用于内网知识库接入；`localhost`、`127.0.0.1`、`169.254.169.254` 等回环或链路本地地址仍会被安全策略拦截。
 :::
 
 ## OCR 方案选择

--- a/web/src/components/FileUploadModal.vue
+++ b/web/src/components/FileUploadModal.vue
@@ -293,7 +293,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch, reactive } from 'vue'
 import { message, Upload, Modal } from 'ant-design-vue'
 import { useUserStore } from '@/stores/user'
 import { useDatabaseStore } from '@/stores/database'
@@ -652,7 +652,7 @@ const handleFetchUrls = async () => {
     }
     if (urlList.value.some((u) => u.url === url)) continue
 
-    const item = { url, status: 'pending', data: null, error: '' }
+    const item = reactive({ url, status: 'pending', data: null, error: '' })
     urlList.value.push(item)
     newItems.push(item)
   }


### PR DESCRIPTION
## Summary
- 允许命中 `YUXI_URL_WHITELIST` 的普通内网 IP URL 抓取，同时继续拦截 loopback/link-local 地址。
- 修复 URL 解析成功后“添加到知识库”按钮仍禁用的问题。
- 补充 URL fetcher 单测和文档说明。

## Test plan
- [x] `python3 -m py_compile backend/package/yuxi/knowledge/utils/url_fetcher.py backend/test/unit/knowledge/test_url_fetcher.py`
- [x] `git diff --check`
- [ ] `cd backend && uv run pytest test/unit/knowledge/test_url_fetcher.py`，本地收集阶段使用 Python 3.10，因项目依赖 Python 3.12 的 `datetime.UTC` 阻塞，非本次断言失败。
- [x] 手动验证 URL 加载后“添加到知识库”按钮可正常启用。