### PR TITLE
feat(config): 升级 MiniMax 默认模型到 M3

### DIFF
--- a/backend/package/yuxi/config/static/models.py
+++ b/backend/package/yuxi/config/static/models.py
@@ -119,13 +119,12 @@ DEFAULT_CHAT_MODEL_PROVIDERS: dict[str, ChatModelProvider] = {
         name="MiniMax",
         url="https://platform.minimaxi.com/docs/guides/models-intro",
         base_url="https://api.minimaxi.com/v1",
-        default="MiniMax-M2.7",
+        default="MiniMax-M3",
         env="MINIMAX_API_KEY",
         models=[
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
         ],
     ),
     "openrouter": ChatModelProvider(


### PR DESCRIPTION
## 变更描述

升级 `minimax` provider 默认模型到 MiniMax-M3,并清理已被取代的旧版本。

具体改动 (`backend/package/yuxi/config/static/models.py`):
- 在 minimax 模型列表头部新增 `MiniMax-M3` 并设为 `default`
- 保留 `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` 作为旧版兼容选项
- 移除已被 M2.7 取代的 `MiniMax-M2.5` / `MiniMax-M2.5-highspeed`

仅触及 minimax provider 自己的 `models` / `default` 字段;Base URL、TTS、其他 provider(siliconflow / modelscope 中以外部托管形式列出的 MiniMax 模型 ID)均未改动,改动行数极小。

## 变更类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**验证方式**:加载 `DEFAULT_CHAT_MODEL_PROVIDERS['minimax']`,断言:
- `default == 'MiniMax-M3'`
- `models[0] == 'MiniMax-M3'`(M3 排在最前)
- `'MiniMax-M2.7'` / `'MiniMax-M2.7-highspeed'` 仍在
- `'MiniMax-M2.5'` / `'MiniMax-M2.5-highspeed'` 已移除

## 说明

MiniMax-M3 已发布,M2.5 系列被同代 M2.7 系列覆盖且文档逐步弃用,保留 M2.7 系列(含 highspeed 变体)以兼容仍在用旧模型的用户。