### PR TITLE
docs: 修正 MinerU 文档解析配置说明

### DIFF
--- a/docs/advanced/document-processing.md
+++ b/docs/advanced/document-processing.md
@@ -68,17 +68,19 @@ Yuxi 支持多种文档格式的智能解析，从简单的文本文件到复杂
 
 ### MinerU（高精度）
 
-首先从官网下载最新的 docker-compose 文件：
+项目已内置 `mineru-api` 服务（位于 `docker-compose.yml`，属于 `all` profile），无需额外下载官方 compose 文件。首次启动会基于 `docker/mineru.Dockerfile` 构建镜像并下载模型，耗时较长。
+
+启动服务（需要 GPU）：
 
 ```bash
-wget https://gcore.jsdelivr.net/gh/opendatalab/MinerU@master/docker/compose.yaml -O docker/mineru.compose.yml
+docker compose --profile all up -d --build mineru-api
 ```
 
-启动服务（需要 GPU）
+该服务在 `30001` 端口提供 `/file_parse` 接口，后端 `api` / `worker` 默认通过 `MINERU_API_URI=http://mineru-api:30001` 连接，通常无需额外配置。
 
-```bash
-docker compose -f docker/mineru.compose.yml --profile openai-server up -d
-```
+::: tip 显存不足
+若显存有限导致启动失败，可在 `docker-compose.yml` 的 `mineru-api` 服务下放开 `--gpu-memory-utilization` 参数（如 `0.5`，必要时进一步降低）。
+:::
 
 ### MinerU Official（云服务）
 

--- a/docs/advanced/document-processing.md
+++ b/docs/advanced/document-processing.md
@@ -68,7 +68,7 @@ Yuxi 支持多种文档格式的智能解析，从简单的文本文件到复杂
 
 ### MinerU（高精度）
 
-项目已内置 `mineru-api` 服务（位于 `docker-compose.yml`，属于 `all` profile），无需额外下载官方 compose 文件。首次启动会基于 `docker/mineru.Dockerfile` 构建镜像并下载模型，耗时较长。
+项目已内置 mineru-api 服务（位于 docker-compose.yml，属于 all profile），无需额外下载官方 compose 文件。首次构建镜像时会基于 docker/mineru.Dockerfile 下载模型，该过程耗时较长。
 
 启动服务（需要 GPU）：
 

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -38,6 +38,7 @@
 - 精简历史兼容层：移除 sandbox provisioner `local` 后端别名、ask_user_question 单问题旧协议、JWT 历史默认密钥特殊判断、内置 Skill `SKILLS.md` 文件名回退、运行事件数字 seq 兼容和前端若干旧字段回退。
 - 重构知识库共享权限：`share_config` 改为全局共享、部门共享、指定人可访问三档，部门共享必须包含当前用户部门，指定人可访问必须包含当前用户，并补充权限过滤测试。
 - 移除知识库沙盒文件系统映射：不再通过 `/home/gem/kbs` 暴露知识库文件树，Agent 继续使用 `query_kb` 与 `open_kb_document` 访问知识库内容。
+- 修复 MinerU 文档解析配置说明：文档处理指南原先指引启动 `openai-server`（30000 端口，仅提供 `/v1/chat/completions`），与解析器实际调用的 `/file_parse` 接口不匹配导致 `mineru_ocr` 不可用；更正为使用项目内置的 `mineru-api` 服务（30001 端口），并补充镜像构建与显存调优说明。
 - 规范 Agent 知识库 Search/Find/Open 工具协议：`resource_id` 统一表示知识库 `kb_id`，Search 返回结构化 `resource_id/file_id/chunk` 结果，新增 `find_kb_document` 在已知文件内做关键词或正则定位，Open 默认窗口扩大到 1800 行。
 - 收敛知识库分块配置：分块预设仅表达策略选择，通用分块参数统一通过 `chunk_parser_config` 传递；移除 `chunk_size`、`chunk_overlap`、`qa_separator` 等旧 root 字段兼容。
 - 收敛知识库文件解析参数：文件级 `processing_params` 统一保存 `ocr_engine` 与 `ocr_engine_config`，解析阶段直接使用该结构并保留分块参数快照。


### PR DESCRIPTION
文档原先指引启动 openai-server(30000)，但该服务仅提供 /v1/chat/completions，与解析器实际调用的 /file_parse 不匹配，导致 mineru_ocr 不可用。更正为使用项目内置的 mineru-api(30001)，并补充镜像构建与显存调优说明。

## 变更描述
更新了mineru操作文档

## 变更类型
- [ ] 新功能
- [ ] Bug 修复
- [x] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**
本机实测解析 9 页 PDF 成功:POST /file_parse HTTP/1.1" 200 OK

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范