### PR TITLE
fix: 修复带图片对话消息不显示，并支持图片点击全屏预览

### DIFF
--- a/backend/package/yuxi/services/agent_run_service.py
+++ b/backend/package/yuxi/services/agent_run_service.py
@@ -85,6 +85,10 @@ def _compact_message_dict(message: dict) -> dict:
     compact = {
         key: message[key] for key in ("id", "role", "content", "type", "message_type") if message.get(key) is not None
     }
+    # image_content 是前端渲染内联图片消息（multimodal_image）的必需字段，
+    # 仅在 init chunk 出现一次，不能当作调试字段精简掉，否则流式期间图片不显示。
+    if message.get("image_content"):
+        compact["image_content"] = message["image_content"]
     extra_metadata = message.get("extra_metadata")
     if isinstance(extra_metadata, dict) and extra_metadata.get("attachments"):
         compact["extra_metadata"] = {"attachments": extra_metadata["attachments"]}
@@ -345,11 +349,17 @@ async def create_agent_run_view(
         if run_type == "resume":
             input_metadata["source"] = "ask_user_question_resume"
 
+        if run_type == "resume":
+            input_message_type = "resume"
+        elif image_content:
+            input_message_type = "multimodal_image"
+        else:
+            input_message_type = "text"
         input_message = Message(
             conversation_id=conversation.id,
             role="user",
             content=input_content,
-            message_type="resume" if run_type == "resume" else "text",
+            message_type=input_message_type,
             image_content=image_content,
             run_id=run_id,
             request_id=request_id,

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -25,7 +25,7 @@
 - 调整内置 MCP 默认项：移除 `sequentialthinking` 的系统内置同步，启动同步时清理历史系统内置记录，保留用户手动创建的同名 MCP。
 - 图片生成能力迁移为 Skill：Qwen-Image 从内置 Python 生成工具迁移到内置 Skill `image-gen`，模型调用与图片下载在 Agent 沙盒中完成，生成结果保存到 outputs 并通过 `present_artifacts` 展示，为多图片生成模型接入复用同一产物展示链路。
 - 降低知识库路由与工具模块复杂度：示例问题生成迁移到知识库 utils，文件上传统一 100 MB 限制，URL 预处理入库路径与旧 `content_type=url` 行为收敛，并修复 uid、导出 MIME 与异常透传等路由问题。
-- 重构智能体配置语义：用户可见的 `AgentConfig` 收敛为数据库持久化的一级 `Agent`，内置 Python Agent 改为智能体后端；新增 `/api/agent` 管理与运行接口，聊天、运行任务、恢复审批和文件预览均从线程绑定的 Agent 解析运行时上下文，前端只提交 `agent_id`，并在模型配置页新增“智能体”管理页签。
+- 重构智能体配置语义：用户可见的 `AgentConfig` 收敛为数据库持久化的一级 `Agent`，内置 Python Agent 改为智能体后端；新增 `/api/agent` 管理与运行接口，聊天、运行任务、恢复审批和文件预览均从线程绑定的 Agent 解析运行时上下文，前端只提交 `agent_id`，并在模型配置页新增“智能体”管理页签。修复该重构引入的图片消息回显丢失问题：`create_agent_run_view` 落库用户消息时 `message_type` 始终写成 `text`，导致历史加载后带图片的消息无法命中前端 `multimodal_image` 渲染分支；同时 SSE `verbose=false` 精简模式把 init chunk 的 `image_content` 当调试字段删除，导致流式期间图片同样不显示（表现为图片发送后短暂出现随即消失、流式结束后才重新出现，但模型始终能正常读取图片）。现按是否携带 `image_content` 写入 `multimodal_image`，并在精简模式下保留 `image_content` 字段。
 - 删除 Upload 与 LightRAG 图谱/知识库能力：知识库类型收敛为 Milvus 与 Dify，只保留 Milvus 知识库内图谱构建/展示/检索，移除独立 `/graph` 页面和默认上传图谱工具。
 - 收敛只读知识源连接器：新增 `ReadOnlyConnectors` 基类，Dify 改为声明自身创建参数与校验规则，新增 Notion Data Source 只读知识库并支持 Search/Find/Open；知识库类型接口返回创建参数 schema，前端新建表单按类型动态渲染非 Milvus 配置并统一保存到 `additional_params`。
 - 新增知识库 Chunk 持久化：Milvus 知识库索引/更新流程会将 chunks 双写到 PostgreSQL `knowledge_chunks` 表与 Milvus，文件内容查看优先查询 PostgreSQL，并为位置信息、图谱实体关联、标签和抽取结果预留结构化字段。

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -55,7 +55,7 @@
 - 工作区知识库分类显示：知识库侧边栏按创建者分组为“我的知识库”和“共享知识库”，自己创建的知识库显示在“我的知识库”下，非自己创建的显示在“共享知识库”下；`knowledge_bases` 表新增 `created_by` 字段记录创建者 uid。
 - 工作区文件上传支持多选：`/workspace/upload` 与 Viewer 工作区上传统一使用 `files` 多文件字段，一次最多上传 50 个文件，批量上传失败时清理本次已写入文件。
 - 聊天附件新增 MinIO tmp 临时上传、可选 PDF/图片解析、确认后加入线程附件的流程；前端改为弹窗内上传、解析与确认。
-- 优化智能体对话页细节：状态面板隐藏空 section，待办名称限制为 20 个中文汉字以内，模型选择器展示供应商名称，并收紧附件状态标签与文件编辑浮动操作样式。
+- 优化智能体对话页细节：状态面板隐藏空 section，待办名称限制为 20 个中文汉字以内，模型选择器展示供应商名称，并收紧附件状态标签与文件编辑浮动操作样式。对话消息中的图片（多模态内联图片与图片附件）支持点击全屏预览，复用文件预览的全屏蒙层交互。
 - 标准化 Agent run/SSE 执行链路：run 创建时持久化输入消息并提交后入队，worker 统一写入 Redis Stream envelope，SSE 输出 `event/data/id`、心跳注释、`Last-Event-ID` 回放和终止 `end` 事件；前端强制使用 run API 并支持 ask_user_question 中断后以 resume run 恢复；事件 envelope 构造收敛到统一 helper，前端优先使用 envelope 一级 `thread_id` 路由。
 - Agent run SSE 新增 `verbose=false` 精简模式：默认仍返回完整事件载荷；精简模式仅在 SSE 输出前重建最小 payload，跳过 `metadata` 和空 `yuxi.agent_state`，将同一 data 内的 `request_id` 外提为单个字段，移除 chunk 中重复的 `meta`、`metadata`、`thread_id`、`response`、空 `namespace` 和图片 base64 等调试字段，保留消息增量、工具调用、工具结果、非空 Agent state、终止状态和 SSE 游标，前端订阅默认使用精简模式。
 - 修复 SiliconFlow MiniMax 工具调用流式兼容：MiniMax 在 OpenAI 兼容流中会在参数增量 chunk 返回空 `function.name`，LangGraph v3 event stream 会将空名称写入最终工具调用并导致工具执行失败；该模型默认对工具调用禁用流式模型响应，保留 LangGraph v3 运行事件并避免 agent-chat 中出现空工具名。

--- a/web/src/components/AgentMessageComponent.vue
+++ b/web/src/components/AgentMessageComponent.vue
@@ -3,7 +3,11 @@
     v-if="message.message_type === 'multimodal_image' && message.image_content"
     class="message-image"
   >
-    <img :src="`data:image/jpeg;base64,${message.image_content}`" alt="用户上传的图片" />
+    <img
+      :src="`data:image/jpeg;base64,${message.image_content}`"
+      alt="用户上传的图片"
+      @click="openImagePreview(`data:image/jpeg;base64,${message.image_content}`, '用户上传的图片')"
+    />
   </div>
   <div
     class="message-box"
@@ -113,7 +117,12 @@
       :key="attachment.fileId"
       class="message-attachment-image"
     >
-      <img :src="attachment.previewUrl" :alt="attachment.name" class="message-attachment-thumb" />
+      <img
+        :src="attachment.previewUrl"
+        :alt="attachment.name"
+        class="message-attachment-thumb"
+        @click="openImagePreview(attachment.previewUrl, attachment.name)"
+      />
     </div>
 
     <div
@@ -132,13 +141,26 @@
       </div>
     </div>
   </div>
+
+  <Teleport to="body">
+    <div
+      v-if="imagePreview.visible"
+      class="message-image-preview-overlay"
+      @click="closeImagePreview"
+    >
+      <button class="message-image-preview-close" title="关闭" @click.stop="closeImagePreview">
+        <X :size="20" />
+      </button>
+      <img :src="imagePreview.src" :alt="imagePreview.alt" class="message-image-preview-img" />
+    </div>
+  </Teleport>
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, onUnmounted } from 'vue'
 import { CaretRightOutlined } from '@ant-design/icons-vue'
 import RefsComponent from '@/components/RefsComponent.vue'
-import { Copy, Check } from 'lucide-vue-next'
+import { Copy, Check, X } from 'lucide-vue-next'
 import ToolCallsGroupComponent from '@/components/ToolCallsGroupComponent.vue'
 import MarkdownPreview from '@/components/common/MarkdownPreview.vue'
 import MentionTextRenderer from '@/components/common/MentionTextRenderer.vue'
@@ -193,6 +215,30 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['retry', 'retryStoppedMessage', 'openRefs'])
+
+// 图片全屏预览
+const imagePreview = ref({ visible: false, src: '', alt: '' })
+
+const handleImagePreviewKeydown = (e) => {
+  if (e.key === 'Escape') {
+    closeImagePreview()
+  }
+}
+
+const openImagePreview = (src, alt = '') => {
+  if (!src) return
+  imagePreview.value = { visible: true, src, alt }
+  window.addEventListener('keydown', handleImagePreviewKeydown)
+}
+
+const closeImagePreview = () => {
+  imagePreview.value = { visible: false, src: '', alt: '' }
+  window.removeEventListener('keydown', handleImagePreviewKeydown)
+}
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleImagePreviewKeydown)
+})
 
 // 复制状态
 const isCopied = ref(false)
@@ -511,6 +557,7 @@ const parsedData = computed(() => {
   height: 100%;
   object-fit: cover;
   display: block;
+  cursor: pointer;
 }
 
 .message-attachment-file {
@@ -631,10 +678,52 @@ const parsedData = computed(() => {
     max-width: 100%;
     max-height: 200px;
     object-fit: contain;
+    cursor: pointer;
   }
 }
 
 .message-md {
   margin: 8px 0;
+}
+
+.message-image-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: rgba(0, 0, 0, 0.75);
+  cursor: zoom-out;
+}
+
+.message-image-preview-img {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 4px;
+  cursor: zoom-out;
+}
+
+.message-image-preview-close {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  color: var(--gray-0);
+  background: rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.28);
+  }
 }
 </style>


### PR DESCRIPTION
## 变更描述

修复对话界面中带图片的用户消息**短暂显示后消失**的问题，并为对话内图片新增点击全屏预览。

### 问题现象
上传图片并发送后，图片和文字会先正常显示，但 1-2 秒后图片从对话中消失（AI 仍能正确读取图片）。上传 DOCX 等文件附件不受影响。

### 根因
图片走 agent run 路径，问题分布在两个生命周期阶段：

1. **历史/流式结束后不显示**：`create_agent_run_view` 落库用户消息时 `message_type` 始终写成 `text`，而前端渲染内联图片的条件是 `message_type === 'multimodal_image' && image_content`，历史加载后无法命中。
2. **流式期间不显示**：SSE `verbose=false` 精简模式的 `_compact_message_dict` 把 init chunk 的 `image_content` 当调试字段删除，导致服务端 init 消息覆盖前端乐观消息后图片消失。

DOCX 正常，是因为文件附件是独立的附件卡片（`extra_metadata.attachments`），不依赖 `message_type` / `image_content`。

### 改动
- `agent_run_service.py`：落库用户消息时按是否携带 `image_content` 写入 `multimodal_image`；精简模式保留 `image_content` 字段。
- `AgentMessageComponent.vue`：对话内多模态内联图片与图片附件支持点击全屏预览，复用文件预览的全屏蒙层交互（Teleport 蒙层 + 点击关闭），不引入额外依赖。
- 补充单元测试，更新 changelog。

> 注：历史中已存为 `text` 的旧图片消息不会回填（不影响模型读取），仅对新发送的消息生效。

## 变更类型
- [x] 新功能（图片点击全屏预览）
- [x] Bug 修复（图片消息不显示）
- [x] 文档更新（changelog）
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

后端单元测试 `test/unit/services/test_agent_run_service.py` 全部通过（15 passed），后端 `ruff` 与前端 `eslint`/`prettier` 均通过。手动验证：发送图片后流式中、流式结束、刷新页面三个阶段图片均正常显示，点击图片可全屏预览。

## 说明
本 PR 含两个提交，分别对应 bug 修复与图片预览功能，可按提交粒度审阅。