### PR TITLE
feat: 新增无状态 Agent 调用接口（RAG 评估 Agent 模式地基）

### DIFF
--- a/backend/package/yuxi/services/agent_invoke_service.py
+++ b/backend/package/yuxi/services/agent_invoke_service.py
@@ -42,11 +42,23 @@ def _message_to_dict(message: Any) -> dict[str, Any]:
 
 
 def _extract_answer(messages: list[Any]) -> str:
-    """取最后一条 AIMessage 的文本内容作为最终答案。"""
+    """取最后一条 AIMessage 的文本内容作为最终答案。
+
+    content 可能是字符串，也可能是内容块列表（Anthropic/Claude、多模态模型常见），
+    后者需要拼接其中的 text 块，避免把列表的 repr 当作答案返回给评估器。
+    """
     for message in reversed(messages):
         if isinstance(message, AIMessage):
             content = message.content
-            return content if isinstance(content, str) else str(content)
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return "".join(
+                    block.get("text", "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                )
+            return ""
     return ""
 
 

--- a/backend/package/yuxi/services/agent_invoke_service.py
+++ b/backend/package/yuxi/services/agent_invoke_service.py
@@ -1,0 +1,131 @@
+"""无状态 Agent 调用接口（RAG 评估 Agent 模式地基）。
+
+提供一个脱离对话上下文、单 query 进、最终答案 + 工具调用 trace 出的 Agent 入口，
+供评估器（以及其他需要程序化调用 Agent 的内部场景）直接 import 调用。
+
+与生产对话链路（agent_run_service / chat_service）的区别：
+- 不创建 conversation、不写 run / message 记录、不入 ARQ 队列、不做 SSE 流式消费。
+- 使用一次性 thread_id，避免污染真实对话的 checkpointer。
+- 以调用方传入的 uid 运行，Agent 按该用户可见的知识库 / Skills / 工具资源运行。
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from sqlalchemy.ext.asyncio import AsyncSession
+from yuxi.agents.buildin import agent_manager
+from yuxi.agents.context import build_agent_input_context, normalize_agent_context_config
+from yuxi.repositories.agent_repository import AgentRepository
+from yuxi.storage.postgres.models_business import User
+from yuxi.utils.logging_config import logger
+
+
+@dataclass(frozen=True)
+class AgentInvokeResult:
+    """单次无状态 Agent 调用的结果。"""
+
+    answer: str
+    messages: list[dict[str, Any]]
+    tool_calls: list[dict[str, Any]]
+
+
+def _message_to_dict(message: Any) -> dict[str, Any]:
+    if hasattr(message, "model_dump"):
+        return message.model_dump()
+    if isinstance(message, dict):
+        return dict(message)
+    return {"content": str(message)}
+
+
+def _extract_answer(messages: list[Any]) -> str:
+    """取最后一条 AIMessage 的文本内容作为最终答案。"""
+    for message in reversed(messages):
+        if isinstance(message, AIMessage):
+            content = message.content
+            return content if isinstance(content, str) else str(content)
+    return ""
+
+
+def _extract_tool_calls(messages: list[Any]) -> list[dict[str, Any]]:
+    """从 trace 中提取工具调用及其结果。
+
+    AIMessage.tool_calls 给出调用入参，ToolMessage 按 tool_call_id 给出对应输出。
+    评估器据此还原 Agent 实际检索 / 调用过程（如知识库检索工具命中的 chunk）。
+    """
+    outputs_by_call_id: dict[str, Any] = {
+        message.tool_call_id: message.content
+        for message in messages
+        if isinstance(message, ToolMessage) and message.tool_call_id
+    }
+
+    tool_calls: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, AIMessage):
+            continue
+        for call in message.tool_calls or []:
+            call_id = call.get("id")
+            tool_calls.append(
+                {
+                    "id": call_id,
+                    "name": call.get("name"),
+                    "args": call.get("args"),
+                    "output": outputs_by_call_id.get(call_id),
+                }
+            )
+    return tool_calls
+
+
+async def invoke_agent_once(
+    *,
+    db: AsyncSession,
+    user: User,
+    agent_id: str,
+    query: str,
+    model_spec: str | None = None,
+) -> AgentInvokeResult:
+    """以调用方传入的用户身份，对指定智能体执行一次无状态调用。
+
+    Args:
+        db: 数据库会话，用于解析智能体配置与用户可见资源。
+        user: 调用方用户，决定 Agent 可访问的知识库 / Skills / 工具范围。
+        agent_id: 智能体 slug。
+        query: 单条用户问题。
+        model_spec: 可选的模型覆盖，留空时使用智能体配置或系统默认模型。
+
+    Returns:
+        AgentInvokeResult：最终答案、完整消息 trace、提取出的工具调用 trace。
+    """
+    agent_item = await AgentRepository(db).get_visible_by_slug(slug=agent_id, user=user)
+    if not agent_item:
+        raise ValueError("智能体不存在或无权限访问")
+
+    backend = agent_manager.get_agent(agent_item.backend_id)
+    if not backend:
+        raise ValueError(f"智能体后端 {agent_item.backend_id} 不存在")
+
+    agent_config = await normalize_agent_context_config(
+        (agent_item.config_json or {}).get("context", {}),
+        db=db,
+        user=user,
+        context_schema=backend.context_schema,
+    )
+
+    thread_id = f"eval-{uuid.uuid4().hex}"
+    uid = str(user.uid)
+    input_context = await build_agent_input_context(agent_config, thread_id=thread_id, uid=uid)
+    if model_spec:
+        input_context["model"] = model_spec
+
+    logger.debug(f"invoke_agent_once: agent={agent_id} uid={uid} thread_id={thread_id}")
+    invoke_result = await backend.invoke_messages([HumanMessage(content=query)], input_context=input_context)
+
+    messages = invoke_result.get("messages", []) if isinstance(invoke_result, dict) else []
+    return AgentInvokeResult(
+        answer=_extract_answer(messages),
+        messages=[_message_to_dict(message) for message in messages],
+        tool_calls=_extract_tool_calls(messages),
+    )

--- a/backend/test/unit/test_agent_invoke_service.py
+++ b/backend/test/unit/test_agent_invoke_service.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault(
+    "SAVE_DIR", os.path.join(os.environ.get("CLAUDE_JOB_DIR", tempfile.gettempdir()), "yuxi-test-saves")
+)
+
+from yuxi.services import agent_invoke_service as service
+
+pytestmark = pytest.mark.unit
+
+
+class FakeUser:
+    def __init__(self, uid: str = "user-1"):
+        self.uid = uid
+        self.role = "user"
+
+
+class FakeAgentItem:
+    def __init__(self, backend_id: str = "ChatbotAgent", config_json: dict | None = None):
+        self.backend_id = backend_id
+        self.config_json = config_json or {"context": {"knowledges": ["kb-1"]}}
+
+
+class FakeBackend:
+    context_schema = object
+
+    def __init__(self, invoke_return):
+        self._invoke_return = invoke_return
+        self.invoke_calls: list[dict] = []
+
+    async def invoke_messages(self, messages, input_context=None, **kwargs):
+        self.invoke_calls.append({"messages": messages, "input_context": input_context})
+        return self._invoke_return
+
+
+def _patch_common(monkeypatch, *, agent_item, backend):
+    class FakeAgentRepository:
+        def __init__(self, db):
+            self.db = db
+
+        async def get_visible_by_slug(self, *, slug, user):
+            return agent_item
+
+    monkeypatch.setattr(service, "AgentRepository", FakeAgentRepository)
+    monkeypatch.setattr(service.agent_manager, "get_agent", lambda backend_id: backend)
+
+    async def fake_normalize(context, *, db, user, context_schema=None):
+        return dict(context or {})
+
+    async def fake_build_input_context(agent_config, *, thread_id, uid, **kwargs):
+        return {**(agent_config or {}), "thread_id": thread_id, "uid": uid}
+
+    monkeypatch.setattr(service, "normalize_agent_context_config", fake_normalize)
+    monkeypatch.setattr(service, "build_agent_input_context", fake_build_input_context)
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_once_extracts_answer_and_tool_trace(monkeypatch):
+    messages = [
+        HumanMessage(content="哪个产品支持离线？"),
+        AIMessage(content="", tool_calls=[{"id": "call-1", "name": "search_kb", "args": {"query": "离线"}}]),
+        ToolMessage(content="chunk: 产品 A 支持离线", tool_call_id="call-1"),
+        AIMessage(content="产品 A 支持离线使用。"),
+    ]
+    backend = FakeBackend({"messages": messages})
+    agent_item = FakeAgentItem()
+    _patch_common(monkeypatch, agent_item=agent_item, backend=backend)
+
+    result = await service.invoke_agent_once(
+        db=None,
+        user=FakeUser("user-1"),
+        agent_id="my-agent",
+        query="哪个产品支持离线？",
+    )
+
+    assert result.answer == "产品 A 支持离线使用。"
+    assert len(result.messages) == 4
+    assert result.tool_calls == [
+        {"id": "call-1", "name": "search_kb", "args": {"query": "离线"}, "output": "chunk: 产品 A 支持离线"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_once_uses_temp_thread_and_caller_uid(monkeypatch):
+    backend = FakeBackend({"messages": [AIMessage(content="ok")]})
+    _patch_common(monkeypatch, agent_item=FakeAgentItem(), backend=backend)
+
+    await service.invoke_agent_once(
+        db=None,
+        user=FakeUser("user-42"),
+        agent_id="my-agent",
+        query="hi",
+        model_spec="openai/gpt-4o",
+    )
+
+    [call] = backend.invoke_calls
+    assert call["input_context"]["uid"] == "user-42"
+    assert call["input_context"]["thread_id"].startswith("eval-")
+    assert call["input_context"]["model"] == "openai/gpt-4o"
+    assert isinstance(call["messages"][0], HumanMessage)
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_once_raises_when_agent_missing(monkeypatch):
+    _patch_common(monkeypatch, agent_item=None, backend=FakeBackend({"messages": []}))
+
+    with pytest.raises(ValueError, match="智能体不存在"):
+        await service.invoke_agent_once(db=None, user=FakeUser(), agent_id="ghost", query="hi")
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_once_returns_empty_answer_without_ai_message(monkeypatch):
+    backend = FakeBackend({"messages": [HumanMessage(content="hi")]})
+    _patch_common(monkeypatch, agent_item=FakeAgentItem(), backend=backend)
+
+    result = await service.invoke_agent_once(db=None, user=FakeUser(), agent_id="my-agent", query="hi")
+
+    assert result.answer == ""
+    assert result.tool_calls == []

--- a/backend/test/unit/test_agent_invoke_service.py
+++ b/backend/test/unit/test_agent_invoke_service.py
@@ -124,3 +124,18 @@ async def test_invoke_agent_once_returns_empty_answer_without_ai_message(monkeyp
 
     assert result.answer == ""
     assert result.tool_calls == []
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_once_joins_text_blocks_from_list_content(monkeypatch):
+    # Anthropic/Claude 与多模态模型的 AIMessage.content 是内容块列表，
+    # 需拼接 text 块而非返回列表 repr。
+    messages = [
+        AIMessage(content=[{"type": "text", "text": "产品 A "}, {"type": "text", "text": "支持离线。"}]),
+    ]
+    backend = FakeBackend({"messages": messages})
+    _patch_common(monkeypatch, agent_item=FakeAgentItem(), backend=backend)
+
+    result = await service.invoke_agent_once(db=None, user=FakeUser(), agent_id="my-agent", query="hi")
+
+    assert result.answer == "产品 A 支持离线。"

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -4,6 +4,12 @@
 
 同一版本的多次功能更新时，应以功能为单位进行更新，比如之前添加了 A 功能的更新，在后续的更新中修复了因 A 功能引入的 bug，那么这个修复说明应该和 A 功能描述放在一起，而不是新增一条修复记录，功能更新同理。
 
+## v0.7.1 (开发中)
+
+### 开发记录
+
+- 新增无状态 Agent 调用接口（`yuxi.services.agent_invoke_service.invoke_agent_once`），作为「RAG 评估支持 Agent 模式」的地基：以调用方传入的 uid 身份对指定智能体执行单 query 调用，复用现有运行上下文解析与 `invoke_messages`，使用一次性 thread_id 避免污染真实对话 checkpointer，不创建 conversation、不写 run/message 记录、不入队列；返回最终答案、完整消息 trace 与提取后的工具调用 trace（含知识库检索工具命中结果），供评估器后续消费。
+
 ## v0.7.0 (2026-06-13)
 
 ### 破坏性变更


### PR DESCRIPTION
## 变更描述

新增无状态 Agent 调用接口 `yuxi.services.agent_invoke_service.invoke_agent_once`，作为 roadmap 中「RAG 评估支持 Agent 模式」的地基（对应「添加 Agent 独立调用接口，方便后续评估使用」一条）。

以调用方传入的用户 uid 身份，对指定智能体执行一次脱离对话上下文的单 query 调用：

- 复用现有运行链路：`normalize_agent_context_config` + `build_agent_input_context` + `BaseAgent.invoke_messages`，不另起一套运行机制。
- 使用一次性 `eval-{uuid}` thread_id，避免污染真实对话的 checkpointer。
- 不创建 conversation、不写 run/message 记录、不入 ARQ 队列、不做 SSE 流式消费。
- 返回最终答案、完整消息 trace、提取后的工具调用 trace（含知识库检索工具命中结果），供后续评估器消费。

本次仅交付地基（内部 service 可调用），不暴露 HTTP 端点、不接入评估器，符合最小变更范围。

## 变更类型

- [x] 新功能

## 测试

- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

新增单元测试 `backend/test/unit/test_agent_invoke_service.py`，4 个用例全部通过：

```
test/unit/test_agent_invoke_service.py::test_invoke_agent_once_extracts_answer_and_tool_trace PASSED
test/unit/test_agent_invoke_service.py::test_invoke_agent_once_uses_temp_thread_and_caller_uid PASSED
test/unit/test_agent_invoke_service.py::test_invoke_agent_once_raises_when_agent_missing PASSED
test/unit/test_agent_invoke_service.py::test_invoke_agent_once_returns_empty_answer_without_ai_message PASSED
======================== 4 passed in 6.74s ========================
```

覆盖：答案与工具 trace 提取、临时 thread_id + 调用方 uid 透传 + model 覆盖、agent 不存在报错、无 AIMessage 时返回空答案。已通过 `ruff format` 与 `ruff check`。

## 说明

- 运行身份采用「调用方传入的 uid」，与现有 `prepare_agent_runtime_context` 的 uid 资源解析一致，Agent 按该用户可见的知识库/Skills/工具运行。
- 后续「RAG 评估支持 Agent 模式」会基于本接口实现；其中「Agent 多次动态检索如何映射 gold_chunk_ids 计算 Recall」属于评估器侧设计，留待下一个 PR 讨论。
