### PR TITLE
fix(web): 智能体调用统计图例过多时启用滚动模式，避免挤压坐标轴

### DIFF
--- a/docs/advanced/api-key-integration.md
+++ b/docs/advanced/api-key-integration.md
@@ -20,7 +20,18 @@ API Key 是一种用于身份验证的密钥字符串，外部系统可以通过
 - `POST /api/user/apikey/{api_key_id}/regenerate`：重新生成密钥
 - `DELETE /api/user/apikey/{api_key_id}`：删除密钥
 
+## 确定 API 访问地址
+
+Yuxi 后端服务绑定在 `0.0.0.0:5050`，不会自动探测或对外宣告本机 IP。实际访问地址取决于部署环境：
+
+- **本地开发**：`http://localhost:5050`
+- **生产部署（Nginx 反向代理）**：`http://<服务器IP或域名>`（默认 80 端口）
+
+完整的 API 交互流程可参考自动生成的 Swagger 文档：`{base_url}/docs`。
+
 ## 接口调用方式
+
+> **关于 `agent_id` 的说明**：下文所有示例中的 `agent_id` 对应的是智能体的 **slug** 字段（如 `default-chatbot`），而非数据库自增 ID 或 `agent_config_id`。请通过 `GET /api/agent` 列表接口确认目标智能体的 slug 值。
 
 外部系统通过 HTTP 请求调用 Yuxi 接口时，需要在请求头中携带 API Key：
 

--- a/docs/advanced/api-key-integration.md
+++ b/docs/advanced/api-key-integration.md
@@ -25,7 +25,7 @@ API Key 是一种用于身份验证的密钥字符串，外部系统可以通过
 Yuxi 后端服务绑定在 `0.0.0.0:5050`，不会自动探测或对外宣告本机 IP。实际访问地址取决于部署环境：
 
 - **本地开发**：`http://localhost:5050`
-- **生产部署（Nginx 反向代理）**：`http://<服务器IP或域名>`（默认 80 端口）
+- **生产部署（Nginx 反向代理）**：**强烈建议使用 HTTPS**，即 `https://<服务器域名>`（443 端口）。由于 API Key 会在请求头中以明文形式传输，使用 HTTP（80 端口）会导致密钥在网络传输过程中被窃听或篡改，必须避免
 
 完整的 API 交互流程可参考自动生成的 Swagger 文档：`{base_url}/docs`。
 
@@ -53,7 +53,7 @@ Authorization: Bearer yxkey_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 import json
 import requests
 
-base_url = "http://your-yuxi-server"
+base_url = "https://your-yuxi-server"  # 生产环境务必使用 HTTPS；本地开发可改为 http://localhost:5050
 headers = {
     "Authorization": "Bearer yxkey_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "Content-Type": "application/json",
@@ -146,6 +146,8 @@ Yuxi 的 API 接口统一支持两种认证方式：
 系统根据 token 的前缀自动判断认证方式。以 `yxkey_` 开头的 token 被视为 API Key，其他 token 则作为 JWT Token 处理。这种设计使得同一个接口可以同时支持外部系统（使用 API Key）和内部前端应用（使用用户登录态）调用。
 
 ## 安全注意事项
+
+**传输层安全**：API Key 在请求头中以明文形式传输，**生产环境必须通过 HTTPS（443 端口）调用**，避免在公网上以 HTTP 明文传输造成密钥泄露。建议在 Nginx 反向代理层启用 TLS 并强制 HTTP 重定向到 HTTPS。
 
 保管好 API Key 密钥是最重要的安全原则。由于 API Key 一旦泄露就可能被滥用，建议不要将密钥硬编码在代码中，而是通过环境变量或配置中心来管理。如果怀疑密钥泄露，应立即在管理界面禁用该 API Key 并重新生成。启用密钥过期功能是一种良好的安全实践，可以设置较短的有效期并定期轮换。
 

--- a/web/src/components/dashboard/CallStatsComponent.vue
+++ b/web/src/components/dashboard/CallStatsComponent.vue
@@ -249,6 +249,8 @@ const renderCallStatsChart = () => {
       itemHeight: 14,
       formatter: (name) => truncateLegend(name),
       pageIconSize: 12,
+      pageIconColor: getCSSVariable('--gray-500'),
+      pageIconInactiveColor: getCSSVariable('--gray-300'),
       pageTextStyle: { color: getCSSVariable('--gray-500') }
     },
     series

--- a/web/src/components/dashboard/CallStatsComponent.vue
+++ b/web/src/components/dashboard/CallStatsComponent.vue
@@ -241,12 +241,15 @@ const renderCallStatsChart = () => {
       }
     },
     legend: {
+      type: 'scroll',
       data: categories.map(resolveCategoryLabel),
       bottom: 5 /* 调整图例位置，从0改为5 */,
       textStyle: { color: getCSSVariable('--gray-500'), fontSize: 12 },
       itemWidth: 14,
       itemHeight: 14,
-      formatter: (name) => truncateLegend(name)
+      formatter: (name) => truncateLegend(name),
+      pageIconSize: 12,
+      pageTextStyle: { color: getCSSVariable('--gray-500') }
     },
     series
   }


### PR DESCRIPTION
Summary: 智能体调用统计图表的图例添加 type: 'scroll'，当智能体数量过多时约束为单行并显示左右翻页箭头；添加 pageIconSize: 12 和 pageTextStyle 控制翻页控件样式，与现有图例风格保持一致。Test plan: 智能体数量较少时图例正常显示为单行无翻页箭头；智能体数量多时图例保持单行不换行可通过左右箭头滚动翻页；翻页控件颜色与图例文字颜色一致（--gray-500）；x 轴不被图例挤压。