### PR TITLE
fix(backend): 修复 Milvus 超长 chunk 入库失败

### DIFF
--- a/backend/package/yuxi/knowledge/chunking/ragflow_like/dispatcher.py
+++ b/backend/package/yuxi/knowledge/chunking/ragflow_like/dispatcher.py
@@ -10,21 +10,23 @@ CHUNK_CONTENT_MAX_BYTES = 65535
 
 
 def _split_text_by_utf8_bytes(text: str, max_bytes: int) -> list[str]:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return [text] if text else []
+
     parts: list[str] = []
     start = 0
-    current_size = 0
+    while start < len(encoded):
+        end = min(start + max_bytes, len(encoded))
+        if end < len(encoded):
+            while end > start and (encoded[end] & 0xC0) == 0x80:
+                end -= 1
+            if end == start:
+                raise ValueError("max_bytes is too small to hold one UTF-8 character")
 
-    for index, char in enumerate(text):
-        char_size = len(char.encode("utf-8"))
-        if index > start and current_size + char_size > max_bytes:
-            parts.append(text[start:index])
-            start = index
-            current_size = 0
-        current_size += char_size
+        parts.append(encoded[start:end].decode("utf-8"))
+        start = end
 
-    tail = text[start:]
-    if tail:
-        parts.append(tail)
     return parts
 
 

--- a/backend/package/yuxi/knowledge/chunking/ragflow_like/dispatcher.py
+++ b/backend/package/yuxi/knowledge/chunking/ragflow_like/dispatcher.py
@@ -2,8 +2,49 @@ from __future__ import annotations
 
 from typing import Any
 
+from yuxi.knowledge.chunking.ragflow_like import nlp
 from yuxi.knowledge.chunking.ragflow_like.parsers import book, general, laws, qa, semantic, separator
 from yuxi.knowledge.chunking.ragflow_like.presets import map_to_internal_parser_id, normalize_chunk_preset_id
+
+CHUNK_CONTENT_MAX_BYTES = 65535
+
+
+def _split_text_by_utf8_bytes(text: str, max_bytes: int) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    current_size = 0
+
+    for index, char in enumerate(text):
+        char_size = len(char.encode("utf-8"))
+        if index > start and current_size + char_size > max_bytes:
+            parts.append(text[start:index])
+            start = index
+            current_size = 0
+        current_size += char_size
+
+    tail = text[start:]
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _ensure_chunk_storage_limit(text_chunks: list[str], parser_config: dict[str, Any]) -> list[str]:
+    chunk_token_num = int(parser_config.get("chunk_token_num", 512) or 512)
+    limited_chunks: list[str] = []
+
+    for chunk in text_chunks:
+        text = (chunk or "").strip()
+        if not text:
+            continue
+
+        token_parts = nlp.hard_split_by_token_limit(text, chunk_token_num)
+        for part in token_parts:
+            if len(part.encode("utf-8")) <= CHUNK_CONTENT_MAX_BYTES:
+                limited_chunks.append(part)
+                continue
+            limited_chunks.extend(_split_text_by_utf8_bytes(part, CHUNK_CONTENT_MAX_BYTES))
+
+    return limited_chunks
 
 
 def _build_chunk_records(
@@ -75,6 +116,7 @@ def chunk_markdown(
     parser_config = params.get("chunk_parser_config") if isinstance(params.get("chunk_parser_config"), dict) else {}
 
     text_chunks = _dispatch_markdown_parser(preset_id, filename, markdown_content, parser_config)
+    text_chunks = _ensure_chunk_storage_limit(text_chunks, parser_config)
     return _build_chunk_records(text_chunks, file_id, filename, markdown_content)
 
 

--- a/backend/package/yuxi/knowledge/chunking/ragflow_like/nlp.py
+++ b/backend/package/yuxi/knowledge/chunking/ragflow_like/nlp.py
@@ -44,15 +44,27 @@ BULLET_PATTERN = [
 ]
 
 MARKDOWN_BULLET_GROUP_INDEX = 4
+ALNUM_TOKEN_CHARS = 16
+
+
+def _estimated_token_spans(text: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for match in re.finditer(r"[A-Za-z0-9_]+|[一-鿿]", text or ""):
+        token = match.group(0)
+        if re.fullmatch(r"[A-Za-z0-9_]+", token):
+            for start in range(match.start(), match.end(), ALNUM_TOKEN_CHARS):
+                spans.append((start, min(start + ALNUM_TOKEN_CHARS, match.end())))
+        else:
+            spans.append((match.start(), match.end()))
+    return spans
 
 
 def count_tokens(text: str) -> int:
     """近似 token 计数，避免引入额外依赖。"""
     if not text:
         return 0
-    # 英文单词 + 数字 + CJK 单字
-    parts = re.findall(r"[A-Za-z0-9_]+|[\u4e00-\u9fff]", text)
-    return max(1, len(parts)) if text.strip() else 0
+    token_count = len(_estimated_token_spans(text))
+    return max(1, token_count) if text.strip() else 0
 
 
 def hard_split_by_token_limit(text: str, chunk_token_num: int, hard_limit_token_num: int | None = None) -> list[str]:
@@ -61,7 +73,7 @@ def hard_split_by_token_limit(text: str, chunk_token_num: int, hard_limit_token_
     hard_limit_token_num 只在调用方显式传入时生效，用于允许略超目标长度的块
     保持完整；默认保持严格不超过 chunk_token_num 的历史行为。
     """
-    token_iter = list(re.finditer(r"[A-Za-z0-9_]+|[一-鿿]", text or ""))
+    token_iter = _estimated_token_spans(text or "")
     if not token_iter:
         cleaned = (text or "").strip()
         return [cleaned] if cleaned else []
@@ -81,7 +93,7 @@ def hard_split_by_token_limit(text: str, chunk_token_num: int, hard_limit_token_
     while index < len(token_iter):
         next_index = min(index + max_tokens, len(token_iter))
         if next_index < len(token_iter):
-            end = token_iter[next_index].start()
+            end = token_iter[next_index][0]
         else:
             end = len(text)
         if text[start:end].strip():

--- a/backend/package/yuxi/knowledge/chunking/ragflow_like/nlp.py
+++ b/backend/package/yuxi/knowledge/chunking/ragflow_like/nlp.py
@@ -51,7 +51,7 @@ def _estimated_token_spans(text: str) -> list[tuple[int, int]]:
     spans: list[tuple[int, int]] = []
     for match in re.finditer(r"[A-Za-z0-9_]+|[一-鿿]", text or ""):
         token = match.group(0)
-        if re.fullmatch(r"[A-Za-z0-9_]+", token):
+        if token[0].isascii():
             for start in range(match.start(), match.end(), ALNUM_TOKEN_CHARS):
                 spans.append((start, min(start + ALNUM_TOKEN_CHARS, match.end())))
         else:

--- a/backend/package/yuxi/knowledge/implementations/milvus.py
+++ b/backend/package/yuxi/knowledge/implementations/milvus.py
@@ -19,9 +19,10 @@ from pymilvus import (
     db,
     utility,
 )
+from pymilvus.exceptions import MilvusException
 
 from yuxi.knowledge.base import FileStatus, KnowledgeBase
-from yuxi.knowledge.chunking.ragflow_like.dispatcher import chunk_markdown
+from yuxi.knowledge.chunking.ragflow_like.dispatcher import CHUNK_CONTENT_MAX_BYTES, chunk_markdown
 from yuxi.knowledge.parser.unified import Parser
 from yuxi.knowledge.utils.kb_utils import resolve_processing_params
 from yuxi.models.providers.cache import model_cache
@@ -32,6 +33,7 @@ from yuxi.utils.datetime_utils import utc_isoformat
 MILVUS_AVAILABLE = True
 CONTENT_SPARSE_FIELD = "content_sparse"
 CONTENT_ANALYZER_PARAMS = {"type": "chinese"}
+MILVUS_CONTENT_MAX_LENGTH = CHUNK_CONTENT_MAX_BYTES
 VECTOR_METRIC_TYPE = "COSINE"
 
 
@@ -281,7 +283,8 @@ class MilvusKB(KnowledgeBase):
         """初始化 Milvus 连接"""
         try:
             # 连接到 Milvus
-            connections.connect(alias=self.connection_alias, uri=self.milvus_uri, token=self.milvus_token)
+            if not connections.has_connection(self.connection_alias):
+                connections.connect(alias=self.connection_alias, uri=self.milvus_uri, token=self.milvus_token)
 
             # 创建数据库（如果不存在）
             try:
@@ -315,6 +318,7 @@ class MilvusKB(KnowledgeBase):
         collection_name = kb_id
 
         try:
+            self._init_connection()
             # 检查集合是否存在
             if utility.has_collection(collection_name, using=self.connection_alias):
                 collection = Collection(name=collection_name, using=self.connection_alias)
@@ -342,7 +346,7 @@ class MilvusKB(KnowledgeBase):
                 logger.info(f"Collection {collection_name} not found, creating new one")
                 return self._create_new_collection(collection_name, embedding_info, kb_id)
 
-        except (connections.MilvusException, RuntimeError) as e:
+        except (MilvusException, RuntimeError) as e:
             logger.error(f"Error checking collection {collection_name}: {e}")
             raise
         except Exception as e:
@@ -361,7 +365,7 @@ class MilvusKB(KnowledgeBase):
             FieldSchema(
                 name="content",
                 dtype=DataType.VARCHAR,
-                max_length=65535,
+                max_length=MILVUS_CONTENT_MAX_LENGTH,
                 enable_analyzer=True,
                 analyzer_params=CONTENT_ANALYZER_PARAMS,
             ),
@@ -464,6 +468,16 @@ class MilvusKB(KnowledgeBase):
         """将文本分割成块"""
         return chunk_markdown(text, file_id, filename, params)
 
+    def _validate_milvus_content_limit(self, chunks: list[dict]) -> None:
+        for chunk in chunks:
+            content = chunk.get("content") or ""
+            content_length = len(content.encode("utf-8"))
+            if content_length > MILVUS_CONTENT_MAX_LENGTH:
+                raise ValueError(
+                    f"Chunk {chunk.get('chunk_id')} content exceeds Milvus content limit: "
+                    f"{content_length} > {MILVUS_CONTENT_MAX_LENGTH}"
+                )
+
     def _build_chunk_pg_records(self, kb_id: str, chunks: list[dict]) -> list[dict[str, Any]]:
         return [
             {
@@ -494,6 +508,8 @@ class MilvusKB(KnowledgeBase):
     ) -> None:
         if not chunks:
             return
+
+        self._validate_milvus_content_limit(chunks)
 
         entities = [
             [chunk["id"] for chunk in chunks],
@@ -652,6 +668,7 @@ class MilvusKB(KnowledgeBase):
             )
 
             if chunks:
+                self._validate_milvus_content_limit(chunks)
                 texts = [chunk["content"] for chunk in chunks]
                 embeddings = await embedding_function(texts)
 
@@ -744,6 +761,7 @@ class MilvusKB(KnowledgeBase):
                 await self.delete_file_chunks_only(kb_id, file_id)
 
                 if chunks:
+                    self._validate_milvus_content_limit(chunks)
                     texts = [chunk["content"] for chunk in chunks]
                     embeddings = await embedding_function(texts)
                     await self._insert_chunks_to_stores(kb_id, file_id, collection, chunks, embeddings)

--- a/backend/package/yuxi/knowledge/implementations/milvus.py
+++ b/backend/package/yuxi/knowledge/implementations/milvus.py
@@ -509,8 +509,6 @@ class MilvusKB(KnowledgeBase):
         if not chunks:
             return
 
-        self._validate_milvus_content_limit(chunks)
-
         entities = [
             [chunk["id"] for chunk in chunks],
             [chunk["content"] for chunk in chunks],

--- a/backend/test/unit/plugins/test_milvus_kb.py
+++ b/backend/test/unit/plugins/test_milvus_kb.py
@@ -1,8 +1,12 @@
+from types import SimpleNamespace
+
+import pytest
 from pymilvus import CollectionSchema, DataType, FieldSchema, Function, FunctionType
 
 from yuxi.knowledge.implementations.milvus import (
     CONTENT_ANALYZER_PARAMS,
     CONTENT_SPARSE_FIELD,
+    MILVUS_CONTENT_MAX_LENGTH,
     VECTOR_METRIC_TYPE,
     MilvusKB,
 )
@@ -65,6 +69,48 @@ def test_build_chunk_pg_records_preserves_extraction_result():
     )
 
     assert records[0]["extraction_result"] == {"entities": ["alpha"]}
+
+
+def test_validate_milvus_content_limit_rejects_oversized_chunk():
+    kb = MilvusKB.__new__(MilvusKB)
+    content = "你" * (MILVUS_CONTENT_MAX_LENGTH // 3 + 1)
+
+    with pytest.raises(ValueError, match="content exceeds Milvus content limit"):
+        kb._validate_milvus_content_limit([
+            {"chunk_id": "chunk-1", "content": content},
+        ])
+
+
+def test_validate_milvus_content_limit_accepts_boundary_chunk():
+    kb = MilvusKB.__new__(MilvusKB)
+
+    kb._validate_milvus_content_limit([
+        {"chunk_id": "chunk-1", "content": "a" * MILVUS_CONTENT_MAX_LENGTH},
+    ])
+
+
+async def test_create_kb_instance_reinitializes_connection_before_collection_check(monkeypatch):
+    kb = MilvusKB.__new__(MilvusKB)
+    kb.databases_meta = {"db": {"embedding_model_spec": "test-provider:test-embedding"}}
+    kb.connection_alias = "test-milvus"
+    init_connection_calls = []
+
+    def get_model_info(model_spec):
+        return SimpleNamespace(model_type="embedding", model_id="test-embedding", dimension=2)
+
+    monkeypatch.setattr(kb, "_init_connection", lambda: init_connection_calls.append(True))
+    monkeypatch.setattr("yuxi.knowledge.implementations.milvus.model_cache.get_model_info", get_model_info)
+    monkeypatch.setattr("yuxi.knowledge.implementations.milvus.utility.has_collection", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        kb,
+        "_create_new_collection",
+        lambda collection_name, embedding_info, kb_id: {"collection_name": collection_name, "kb_id": kb_id},
+    )
+
+    result = await kb._create_kb_instance("db", {})
+
+    assert init_connection_calls == [True]
+    assert result == {"collection_name": "db", "kb_id": "db"}
 
 
 async def test_keyword_mode_uses_milvus_bm25_search():
@@ -177,7 +223,7 @@ def test_collection_supports_bm25_requires_analyzed_content_sparse_field_and_fun
             FieldSchema(
                 name="content",
                 dtype=DataType.VARCHAR,
-                max_length=65535,
+                max_length=MILVUS_CONTENT_MAX_LENGTH,
                 enable_analyzer=True,
                 analyzer_params=CONTENT_ANALYZER_PARAMS,
             ),

--- a/backend/test/unit/plugins/test_ragflow_like_chunking.py
+++ b/backend/test/unit/plugins/test_ragflow_like_chunking.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.append(os.getcwd())
 
-from yuxi.knowledge.chunking.ragflow_like.dispatcher import chunk_markdown
+from yuxi.knowledge.chunking.ragflow_like.dispatcher import CHUNK_CONTENT_MAX_BYTES, chunk_markdown
 from yuxi.knowledge.chunking.ragflow_like.nlp import bullets_category, count_tokens
 from yuxi.knowledge.chunking.ragflow_like.utils.semantic_utils import split_sentences_chinese
 from yuxi.knowledge.chunking.ragflow_like.presets import (
@@ -59,6 +59,23 @@ def test_resolve_chunk_processing_params_returns_only_nested_keys() -> None:
     assert resolved["chunk_preset_id"] == "general"
     assert resolved["chunk_engine_version"] == CHUNK_ENGINE_VERSION
     assert len(resolved) == 3
+
+
+def test_general_chunking_should_split_long_continuous_ascii_for_storage_limit() -> None:
+    content = "a" * (CHUNK_CONTENT_MAX_BYTES * 2 + 123)
+
+    chunks = chunk_markdown(
+        markdown_content=content,
+        file_id="file_long_ascii",
+        filename="long.md",
+        processing_params={"chunk_preset_id": "general", "chunk_parser_config": {"chunk_token_num": 512}},
+    )
+
+    assert len(chunks) > 1
+    assert "".join(chunk["content"] for chunk in chunks) == content
+    for chunk in chunks:
+        assert len(chunk["content"].encode("utf-8")) <= CHUNK_CONTENT_MAX_BYTES
+        assert count_tokens(chunk["content"]) <= 512
 
 
 def test_qa_chunking_from_markdown_headings() -> None:

--- a/backend/test/unit/plugins/test_ragflow_like_chunking.py
+++ b/backend/test/unit/plugins/test_ragflow_like_chunking.py
@@ -78,6 +78,22 @@ def test_general_chunking_should_split_long_continuous_ascii_for_storage_limit()
         assert count_tokens(chunk["content"]) <= 512
 
 
+def test_general_chunking_should_not_split_utf8_character_boundary() -> None:
+    content = "a" * (CHUNK_CONTENT_MAX_BYTES - 1) + "你" * 32
+
+    chunks = chunk_markdown(
+        markdown_content=content,
+        file_id="file_utf8_boundary",
+        filename="utf8.md",
+        processing_params={"chunk_preset_id": "general", "chunk_parser_config": {"chunk_token_num": 100000}},
+    )
+
+    assert len(chunks) == 2
+    assert "".join(chunk["content"] for chunk in chunks) == content
+    for chunk in chunks:
+        assert len(chunk["content"].encode("utf-8")) <= CHUNK_CONTENT_MAX_BYTES
+
+
 def test_qa_chunking_from_markdown_headings() -> None:
     content = """
 # 问题一

--- a/backend/test/unit/test_chunking_token_limit.py
+++ b/backend/test/unit/test_chunking_token_limit.py
@@ -104,6 +104,14 @@ class TestHardSplitByTokenLimit:
         for chunk in result:
             assert nlp.count_tokens(chunk) <= 512
 
+    def test_splits_long_continuous_ascii_text(self):
+        text = "a" * 20000
+        result = nlp.hard_split_by_token_limit(text, 512)
+        assert len(result) > 1
+        assert "".join(result) == text
+        for chunk in result:
+            assert nlp.count_tokens(chunk) <= 512
+
     def test_empty_text_returns_empty(self):
         assert nlp.hard_split_by_token_limit("", 512) == []
 
@@ -120,6 +128,9 @@ class TestHardSplitByTokenLimit:
         text = "，。！？"
         result = nlp.hard_split_by_token_limit(text, 512)
         assert result == ["，。！？"]
+
+    def test_count_tokens_estimates_long_continuous_ascii(self):
+        assert nlp.count_tokens("a" * 1600) == 100
 
 
 # ── general._ensure_chunk_token_limit ──────────────────────────────

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -28,7 +28,7 @@
 - 重构智能体配置语义：用户可见的 `AgentConfig` 收敛为数据库持久化的一级 `Agent`，内置 Python Agent 改为智能体后端；新增 `/api/agent` 管理与运行接口，聊天、运行任务、恢复审批和文件预览均从线程绑定的 Agent 解析运行时上下文，前端只提交 `agent_id`，并在模型配置页新增“智能体”管理页签。
 - 删除 Upload 与 LightRAG 图谱/知识库能力：知识库类型收敛为 Milvus 与 Dify，只保留 Milvus 知识库内图谱构建/展示/检索，移除独立 `/graph` 页面和默认上传图谱工具。
 - 收敛只读知识源连接器：新增 `ReadOnlyConnectors` 基类，Dify 改为声明自身创建参数与校验规则，新增 Notion Data Source 只读知识库并支持 Search/Find/Open；知识库类型接口返回创建参数 schema，前端新建表单按类型动态渲染非 Milvus 配置并统一保存到 `additional_params`。
-- 新增知识库 Chunk 持久化：Milvus 知识库索引/更新流程会将 chunks 双写到 PostgreSQL `knowledge_chunks` 表与 Milvus，文件内容查看优先查询 PostgreSQL，并为位置信息、图谱实体关联、标签和抽取结果预留结构化字段。
+- 新增知识库 Chunk 持久化：Milvus 知识库索引/更新流程会将 chunks 双写到 PostgreSQL `knowledge_chunks` 表与 Milvus，文件内容查看优先查询 PostgreSQL，并为位置信息、图谱实体关联、标签和抽取结果预留结构化字段；写入 Milvus 前会按 `VARCHAR` 字段上限兜底拆分超长 chunk，避免单个 chunk 内容超过 Milvus 字段长度导致索引失败。
 - 完善 Milvus 知识库图谱构建：修复 Chunk 图谱写入返回值、Neo4j 同步写入阻塞事件循环、重复构建任务竞态、图谱查询提前终止、Neo4j 连接复用、LLM 抽取超时重试和前端错误详情展示等问题；图谱构建会将 entity/triple 本体与 chunk 引用写入 PostgreSQL，并为唯一 entity/triple 建立 Milvus 语义索引，单文件删除时同步清理图谱引用和孤儿向量。
 - 优化图谱抽取器配置：未配置时在图谱中心展示配置入口，抽取方案收敛为 LLM，前端仅保留“更多拓展中”占位；LLM 抽取器使用固定 Prompt + 自定义 Schema，并支持模型参数与并发队列数；已配置后允许修改参数并提示重置重抽风险。修复上传并入库新文件时旧内存 metadata 覆盖数据库图谱配置的问题。
 - 新增 Milvus 图谱检索链路：Query 可召回图谱实体和三元组，结合 Chunk 命中实体构造 seed entity，读取 Neo4j 2-hop 子图后用 igraph 执行 PPR，最终以 Chunk 为产物并通过 RRF 与原 Chunk 召回融合；检索配置改为 dataclass 元数据生成，支持 `depend_on` 控制重排序和图检索参数展示。


### PR DESCRIPTION
## 变更描述
修复 general 分块在超长连续内容场景下可能输出超过 Milvus `VARCHAR(65535)` 限制的 chunk，导致文件入库失败的问题。

主要改动：
- 在 ragflow-like 分块出口统一限制 chunk content 的 UTF-8 字节长度。
- 修正超长连续英文/数字串的 token 估算与硬切分逻辑，避免 `aaaaaaaa...`、超长 URL/base64 等被低估为极少 token。
- 在 Milvus 写入前增加 content 字段长度校验，提供更清晰的错误信息。
- 补充 general 分块、token 硬切分和 Milvus content 边界相关单元测试。
- 更新 changelog。

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [x] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

- 相关单元测试通过。
- 已在 Docker 容器中运行实际文件入库测试，入库正常。

## 说明

本次修复将超长 chunk 的处理放在 chunking 层，Milvus 层仅保留存储边界校验，避免在存储层修改 chunk 内容、ID 或元数据。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)