### PR TITLE
refactor(mcp): split MCP service into modular sub-packages (PR 1)

### DIFF
--- a/backend/package/yuxi/agents/__init__.py
+++ b/backend/package/yuxi/agents/__init__.py
@@ -12,7 +12,7 @@ from yuxi.agents.state import BaseState
 from yuxi.agents.toolkits.utils import get_tool_info
 
 # MCP - Agent 层统一入口（自动过滤 disabled_tools）
-from yuxi.services.mcp_service import get_enabled_mcp_tools
+from yuxi.services.mcp.tool_registry_service import get_enabled_mcp_tools
 
 __all__ = [
     # Base classes

--- a/backend/package/yuxi/agents/buildin/chatbot/graph.py
+++ b/backend/package/yuxi/agents/buildin/chatbot/graph.py
@@ -13,7 +13,7 @@ from yuxi.agents.middlewares import (
 )
 from yuxi.agents.middlewares.knowledge_base_middleware import KnowledgeBaseMiddleware
 from yuxi.agents.middlewares.skills_middleware import SkillsMiddleware
-from yuxi.services.mcp_service import get_tools_from_all_servers
+from yuxi.services.mcp.tool_registry_service import get_tools_from_all_servers
 from yuxi.services.subagent_service import get_subagents_from_names
 
 from .prompt import TODO_MID_PROMPT, build_prompt_with_context

--- a/backend/package/yuxi/agents/buildin/deep_agent/graph.py
+++ b/backend/package/yuxi/agents/buildin/deep_agent/graph.py
@@ -17,7 +17,7 @@ from yuxi.agents.middlewares import (
 from yuxi.agents.middlewares.knowledge_base_middleware import KnowledgeBaseMiddleware
 from yuxi.agents.middlewares.skills_middleware import SkillsMiddleware
 from yuxi.agents.toolkits.buildin.tools import _create_tavily_search
-from yuxi.services.mcp_service import get_tools_from_all_servers
+from yuxi.services.mcp.tool_registry_service import get_tools_from_all_servers
 from yuxi.services.subagent_service import get_subagents_from_names
 from yuxi.utils import logger
 

--- a/backend/package/yuxi/agents/middlewares/dynamic_tool_middleware.py
+++ b/backend/package/yuxi/agents/middlewares/dynamic_tool_middleware.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResponse
 
-from yuxi.services.mcp_service import get_mcp_tools
+from yuxi.services.mcp.tool_registry_service import get_mcp_tools
 from yuxi.utils import logger
 
 

--- a/backend/package/yuxi/agents/middlewares/runtime_config_middleware.py
+++ b/backend/package/yuxi/agents/middlewares/runtime_config_middleware.py
@@ -8,7 +8,7 @@ from langchain_core.messages import SystemMessage
 
 from yuxi.agents import load_chat_model
 from yuxi.agents.toolkits import get_all_tool_instances
-from yuxi.services.mcp_service import get_enabled_mcp_tools
+from yuxi.services.mcp.tool_registry_service import get_enabled_mcp_tools
 from yuxi.utils.datetime_utils import shanghai_now
 from yuxi.utils.logging_config import logger
 

--- a/backend/package/yuxi/agents/middlewares/skills_middleware.py
+++ b/backend/package/yuxi/agents/middlewares/skills_middleware.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from yuxi.agents.toolkits import get_all_tool_instances
 from yuxi.repositories.skill_repository import SkillRepository
-from yuxi.services.mcp_service import get_enabled_mcp_tools
+from yuxi.services.mcp.tool_registry_service import get_enabled_mcp_tools
 from yuxi.services.skill_service import _normalize_string_list, is_valid_skill_slug
 from yuxi.storage.postgres.manager import pg_manager
 from yuxi.utils.logging_config import logger

--- a/backend/package/yuxi/services/mcp/__init__.py
+++ b/backend/package/yuxi/services/mcp/__init__.py
@@ -1,0 +1,52 @@
+"""MCP service package."""
+
+from . import server_service, tool_registry_service
+from yuxi.services.mcp.server_service import (
+    create_mcp_server,
+    delete_mcp_server,
+    ensure_builtin_mcp_servers_in_db,
+    get_all_mcp_servers,
+    get_enabled_mcp_server_config,
+    get_enabled_mcp_server_names,
+    get_mcp_server,
+    get_servers_config,
+    set_server_enabled,
+    toggle_tool_enabled,
+    update_mcp_server,
+)
+from yuxi.services.mcp.tool_registry_service import (
+    clear_mcp_cache,
+    clear_mcp_server_tools_cache,
+    get_all_mcp_tools,
+    get_enabled_mcp_tools,
+    get_mcp_client,
+    get_mcp_tools,
+    get_mcp_tools_stats,
+    get_tools_from_all_servers,
+    to_camel_case,
+)
+
+__all__ = [
+    "clear_mcp_cache",
+    "clear_mcp_server_tools_cache",
+    "create_mcp_server",
+    "delete_mcp_server",
+    "ensure_builtin_mcp_servers_in_db",
+    "get_all_mcp_servers",
+    "get_all_mcp_tools",
+    "get_enabled_mcp_server_config",
+    "get_enabled_mcp_server_names",
+    "get_enabled_mcp_tools",
+    "get_mcp_client",
+    "get_mcp_server",
+    "get_mcp_tools",
+    "get_mcp_tools_stats",
+    "get_servers_config",
+    "get_tools_from_all_servers",
+    "server_service",
+    "set_server_enabled",
+    "to_camel_case",
+    "toggle_tool_enabled",
+    "tool_registry_service",
+    "update_mcp_server",
+]

--- a/backend/package/yuxi/services/mcp/server_service.py
+++ b/backend/package/yuxi/services/mcp/server_service.py
@@ -1,21 +1,13 @@
-"""MCP Service - Unified business logic and state management for MCP.
+"""MCP server configuration service.
 
 Responsibilities:
 - Server configuration CRUD operations
 - Built-in configuration synchronization (Code <-> Database)
-- Unified entry point for Agent tool retrieval (auto-filtering disabled_tools)
-- MCP Client and Tools management (formerly in agents/common/mcp.py)
 """
 
-import asyncio
-import hashlib
-import json
-import re
 import traceback
-from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
-from langchain_mcp_adapters.client import MultiServerMCPClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from yuxi.storage.postgres.models_business import MCPServer
@@ -25,15 +17,6 @@ from yuxi.utils import logger
 # === Global Cache & State ===
 # =============================================================================
 
-# Global Lock for MCP state
-_mcp_lock = asyncio.Lock()
-
-# 本地仅缓存工具对象。配置始终以数据库为准，每次按 server_name 现查。
-# cache key 使用 server_name:config_hash，当配置变化时会自然失效。
-_mcp_tools_cache: dict[str, list[Callable[..., Any]]] = {}
-
-# MCP tools statistics (for reporting enabled/disabled counts)
-_mcp_tools_stats: dict[str, dict[str, int]] = {}
 _UNSET = object()
 
 # Default MCP Server configurations (Imported to DB on first run)
@@ -70,7 +53,7 @@ _SYNCED_MCP_FIELDS = (
 )
 
 # =============================================================================
-# === Core Logic (Moved from agents/common/mcp.py) ===
+# === Built-in Server Synchronization ===
 # =============================================================================
 
 
@@ -157,30 +140,6 @@ async def ensure_builtin_mcp_servers_in_db() -> None:
         logger.error(f"Failed to ensure builtin MCP servers in database: {e}, traceback: {traceback.format_exc()}")
 
 
-async def get_mcp_client(
-    server_configs: dict[str, Any] | None = None,
-) -> MultiServerMCPClient | None:
-    """Initializes an MCP client with the given server configurations."""
-    try:
-        client = MultiServerMCPClient(server_configs)  # pyright: ignore[reportArgumentType]
-        logger.info(f"Initialized MCP client with servers: {list(server_configs.keys())}")
-        return client
-    except Exception as e:
-        logger.error("Failed to initialize MCP client: {}", e)
-        return None
-
-
-def to_camel_case(s: str) -> str:
-    """Convert string to lowerCamelCase."""
-
-    # Handle - and _
-    s = re.sub(r"[-_]+(.)", lambda m: m.group(1).upper(), s)
-    # Lowercase first letter
-    if len(s) > 0:
-        s = s[0].lower() + s[1:]
-    return s
-
-
 async def _load_enabled_mcp_server_configs(
     *,
     names: list[str] | None = None,
@@ -213,147 +172,10 @@ async def get_enabled_mcp_server_names(*, db: AsyncSession | None = None) -> lis
     return list(configs.keys())
 
 
-async def get_mcp_tools(
-    server_name: str,
-    additional_servers: dict[str, dict[str, Any]] | None = None,
-    disabled_tools: list[str] = None,
-    cache: bool = True,
-    force_refresh: bool = False,
-) -> list[Callable[..., Any]]:
-    """Get MCP tools for a specific server.
+def _clear_mcp_server_tools_cache(server_name: str) -> None:
+    from yuxi.services.mcp.tool_registry_service import clear_mcp_server_tools_cache
 
-    Architecture:
-    1. Fetching: Connects to MCP server to get ALL tools.
-    2. Caching: Stores the FULL, UNFILTERED list of tools in `_mcp_tools_cache`.
-    3. Filtering: Filters the return value based on `disabled_tools` argument.
-
-    Args:
-        server_name: Server name
-        additional_servers: Additional server configurations
-        disabled_tools: List of tool names to filter out from the RETURN value (does not affect cache)
-        cache: Whether to use/update the cache (default: True)
-        force_refresh: Whether to force a refresh from the server (default: False)
-    """
-    if additional_servers and server_name in additional_servers:
-        server_config = additional_servers[server_name]
-    else:
-        server_config = await get_enabled_mcp_server_config(server_name)
-
-    if server_config is None:
-        logger.warning(f"MCP server '{server_name}' not found in database or disabled")
-        return []
-
-    # 配置 hash 直接基于完整配置生成。只要数据库中的配置发生变化，
-    # 本地工具缓存 key 就会变化，从而自然触发重建。
-    config_payload = json.dumps(server_config, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
-    config_hash = hashlib.sha256(config_payload.encode("utf-8")).hexdigest()[:16]
-    cache_key = f"{server_name}:{config_hash}"
-
-    all_processed_tools: list[Callable[..., Any]] = []
-
-    async with _mcp_lock:
-        if not force_refresh and cache and cache_key in _mcp_tools_cache:
-            all_processed_tools = _mcp_tools_cache[cache_key]
-
-    if not all_processed_tools:
-        try:
-            # disabled_tools 只影响返回值过滤，不参与 MCP client 建连参数。
-            client_config = {k: v for k, v in server_config.items() if k not in ("disabled_tools",)}
-
-            client = await get_mcp_client({server_name: client_config})
-            if client is None:
-                return []
-
-            raw_tools = cast(list[Any], await client.get_tools())
-
-            server_cc = to_camel_case(server_name)
-            for tool in raw_tools:
-                original_name = tool.name
-                tool_cc = to_camel_case(original_name)
-                unique_id = f"mcp__{server_cc}__{tool_cc}"
-
-                if tool.metadata is None:
-                    tool.metadata = {}
-                tool.metadata["id"] = unique_id
-                # 开启错误处理，防止工具调用抛出 ToolException 时击穿服务
-                tool.handle_tool_error = True
-                all_processed_tools.append(tool)
-
-            if cache:
-                async with _mcp_lock:
-                    stale_keys = [
-                        key for key in _mcp_tools_cache if key.startswith(f"{server_name}:") and key != cache_key
-                    ]
-                    for stale_key in stale_keys:
-                        _mcp_tools_cache.pop(stale_key, None)
-                    _mcp_tools_cache[cache_key] = all_processed_tools
-
-                global_config_disabled = server_config.get("disabled_tools") or []
-                enabled_count = len([t for t in all_processed_tools if t.name not in global_config_disabled])
-                _mcp_tools_stats[server_name] = {
-                    "total": len(all_processed_tools),
-                    "enabled": enabled_count,
-                    "disabled": len(all_processed_tools) - enabled_count,
-                }
-
-                logger.info(
-                    f"Refreshed MCP tools cache for '{server_name}' with key '{cache_key}': "
-                    f"{len(all_processed_tools)} tools loaded."
-                )
-
-        except Exception as e:
-            logger.error(
-                f"Failed to load tools from MCP server '{server_name}': {e}, traceback: {traceback.format_exc()}"
-            )
-            return []
-
-    # 3. Filtering (Apply to Return Value Only)
-    if disabled_tools:
-        filtered_tools = [t for t in all_processed_tools if t.name not in disabled_tools]
-        logger.debug(
-            f"Returning {len(filtered_tools)}/{len(all_processed_tools)} tools for '{server_name}' "
-            f"(filtered {len(disabled_tools)} by argument)"
-        )
-        return filtered_tools
-
-    return all_processed_tools
-
-
-async def get_tools_from_all_servers() -> list[Callable[..., Any]]:
-    """Get all tools from all configured MCP servers."""
-    server_configs = await _load_enabled_mcp_server_configs()
-    all_tools = []
-    for server_name in server_configs:
-        tools = await get_mcp_tools(server_name, additional_servers=server_configs)
-        all_tools.extend(tools)
-    return all_tools
-
-
-def clear_mcp_cache() -> None:
-    """Clear the MCP tools cache (useful for testing)."""
-    global _mcp_tools_cache, _mcp_tools_stats
-    _mcp_tools_cache = {}
-    _mcp_tools_stats = {}
-
-
-def clear_mcp_server_tools_cache(server_name: str) -> None:
-    """Clear the tools cache for a specific MCP server."""
-    global _mcp_tools_cache, _mcp_tools_stats
-    server_prefix = f"{server_name}:"
-    stale_keys = [key for key in _mcp_tools_cache if key.startswith(server_prefix)]
-    for stale_key in stale_keys:
-        _mcp_tools_cache.pop(stale_key, None)
-    _mcp_tools_stats.pop(server_name, None)
-    logger.info(f"Cleared tools cache for MCP server '{server_name}'")
-
-
-def get_mcp_tools_stats(server_name: str) -> dict[str, int] | None:
-    """Get tools statistics for a MCP server.
-
-    Returns:
-        dict with 'total', 'enabled', 'disabled' counts, or None if not available
-    """
-    return _mcp_tools_stats.get(server_name)
+    clear_mcp_server_tools_cache(server_name)
 
 
 # =============================================================================
@@ -416,7 +238,7 @@ async def create_mcp_server(
     await db.commit()
     await db.refresh(server)
 
-    clear_mcp_server_tools_cache(name)
+    _clear_mcp_server_tools_cache(name)
 
     logger.info(f"Created MCP server '{name}'")
     return server
@@ -471,7 +293,7 @@ async def update_mcp_server(
     await db.commit()
     await db.refresh(server)
 
-    clear_mcp_server_tools_cache(name)
+    _clear_mcp_server_tools_cache(name)
 
     logger.info(f"Updated MCP server '{name}'")
     return server
@@ -486,7 +308,7 @@ async def delete_mcp_server(db: AsyncSession, name: str) -> bool:
     await db.delete(server)
     await db.commit()
 
-    clear_mcp_server_tools_cache(name)
+    _clear_mcp_server_tools_cache(name)
 
     logger.info(f"Deleted MCP server '{name}'")
     return True
@@ -511,7 +333,7 @@ async def set_server_enabled(
     await db.commit()
 
     is_enabled = bool(server.enabled)
-    clear_mcp_server_tools_cache(name)
+    _clear_mcp_server_tools_cache(name)
 
     logger.info(f"Set MCP server '{name}' enabled={is_enabled}")
     return is_enabled, server
@@ -553,38 +375,15 @@ async def toggle_tool_enabled(
     await db.commit()
 
     # Clear tool cache (re-filtered on next fetch)
-    clear_mcp_server_tools_cache(server_name)
+    _clear_mcp_server_tools_cache(server_name)
 
     logger.info(f"Toggled tool '{tool_name}' for server '{server_name}' enabled={enabled}")
     return enabled, server
 
 
 # =============================================================================
-# === Unified Entry Points (Wrappers) ===
+# === Server Config Entry Points ===
 # =============================================================================
-
-
-async def get_enabled_mcp_tools(server_name: str) -> list:
-    """Get MCP server tools (auto-filtering disabled_tools).
-
-    Unified entry point for Agents, automatically:
-    1. Gets the latest server config from database
-    2. Gets all tools
-    3. Filters out disabled_tools
-
-    Args:
-        server_name: Server name
-
-    Returns:
-        List of enabled tools
-    """
-    config = await get_enabled_mcp_server_config(server_name)
-    if config is None:
-        logger.warning(f"MCP server '{server_name}' not found in database or disabled")
-        return []
-
-    disabled_tools = config.get("disabled_tools") or []
-    return await get_mcp_tools(server_name, additional_servers={server_name: config}, disabled_tools=disabled_tools)
 
 
 async def get_servers_config(names: list[str]) -> dict[str, dict[str, Any]]:
@@ -597,30 +396,3 @@ async def get_servers_config(names: list[str]) -> dict[str, dict[str, Any]]:
         {name: config} dictionary, containing only found servers
     """
     return await _load_enabled_mcp_server_configs(names=names)
-
-
-async def get_all_mcp_tools(server_name: str) -> list:
-    """Get all tools of an MCP server (no filtering).
-
-    For management UI to display tool list, supports viewing all tools and their enabled status.
-    Does NOT update the global tools cache to avoid polluting agent's filtered view.
-
-    Args:
-        server_name: Server name
-
-    Returns:
-        List of all tools (unfiltered)
-    """
-    config = await get_enabled_mcp_server_config(server_name)
-    if config is None:
-        logger.warning(f"MCP server '{server_name}' not found in database or disabled")
-        return []
-
-    # Get all tools (no filtering, force refresh, no cache update)
-    return await get_mcp_tools(
-        server_name,
-        additional_servers={server_name: config},
-        disabled_tools=[],
-        cache=False,
-        force_refresh=True,
-    )

--- a/backend/package/yuxi/services/mcp/tool_registry_service.py
+++ b/backend/package/yuxi/services/mcp/tool_registry_service.py
@@ -1,0 +1,258 @@
+"""MCP tool discovery and cache service.
+
+Responsibilities:
+- Unified entry point for Agent tool retrieval (auto-filtering disabled_tools)
+- MCP Client and Tools management (formerly in agents/common/mcp.py)
+"""
+
+import asyncio
+import hashlib
+import json
+import re
+import traceback
+from collections.abc import Callable
+from typing import Any, cast
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from yuxi.services.mcp.server_service import _load_enabled_mcp_server_configs, get_enabled_mcp_server_config
+from yuxi.utils import logger
+
+# =============================================================================
+# === Global Cache & State ===
+# =============================================================================
+
+# Global Lock for MCP state
+_mcp_lock = asyncio.Lock()
+
+# 本地仅缓存工具对象。配置始终以数据库为准，每次按 server_name 现查。
+# cache key 使用 server_name:config_hash，当配置变化时会自然失效。
+_mcp_tools_cache: dict[str, list[Callable[..., Any]]] = {}
+
+# MCP tools statistics (for reporting enabled/disabled counts)
+_mcp_tools_stats: dict[str, dict[str, int]] = {}
+
+# =============================================================================
+# === Core Logic (Moved from agents/common/mcp.py) ===
+# =============================================================================
+
+
+async def get_mcp_client(
+    server_configs: dict[str, Any] | None = None,
+) -> MultiServerMCPClient | None:
+    """Initializes an MCP client with the given server configurations."""
+    try:
+        client = MultiServerMCPClient(server_configs)  # pyright: ignore[reportArgumentType]
+        logger.info(f"Initialized MCP client with servers: {list(server_configs.keys())}")
+        return client
+    except Exception as e:
+        logger.error("Failed to initialize MCP client: {}", e)
+        return None
+
+
+def to_camel_case(s: str) -> str:
+    """Convert string to lowerCamelCase."""
+
+    # Handle - and _
+    s = re.sub(r"[-_]+(.)", lambda m: m.group(1).upper(), s)
+    # Lowercase first letter
+    if len(s) > 0:
+        s = s[0].lower() + s[1:]
+    return s
+
+
+async def get_mcp_tools(
+    server_name: str,
+    additional_servers: dict[str, dict[str, Any]] | None = None,
+    disabled_tools: list[str] = None,
+    cache: bool = True,
+    force_refresh: bool = False,
+) -> list[Callable[..., Any]]:
+    """Get MCP tools for a specific server.
+
+    Architecture:
+    1. Fetching: Connects to MCP server to get ALL tools.
+    2. Caching: Stores the FULL, UNFILTERED list of tools in `_mcp_tools_cache`.
+    3. Filtering: Filters the return value based on `disabled_tools` argument.
+
+    Args:
+        server_name: Server name
+        additional_servers: Additional server configurations
+        disabled_tools: List of tool names to filter out from the RETURN value (does not affect cache)
+        cache: Whether to use/update the cache (default: True)
+        force_refresh: Whether to force a refresh from the server (default: False)
+    """
+    if additional_servers and server_name in additional_servers:
+        server_config = additional_servers[server_name]
+    else:
+        server_config = await get_enabled_mcp_server_config(server_name)
+
+    if server_config is None:
+        logger.warning(f"MCP server '{server_name}' not found in database or disabled")
+        return []
+
+    # 配置 hash 直接基于完整配置生成。只要数据库中的配置发生变化，
+    # 本地工具缓存 key 就会变化，从而自然触发重建。
+    config_payload = json.dumps(server_config, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    config_hash = hashlib.sha256(config_payload.encode("utf-8")).hexdigest()[:16]
+    cache_key = f"{server_name}:{config_hash}"
+
+    all_processed_tools: list[Callable[..., Any]] = []
+
+    async with _mcp_lock:
+        if not force_refresh and cache and cache_key in _mcp_tools_cache:
+            all_processed_tools = _mcp_tools_cache[cache_key]
+
+    if not all_processed_tools:
+        try:
+            # disabled_tools 只影响返回值过滤，不参与 MCP client 建连参数。
+            client_config = {k: v for k, v in server_config.items() if k not in ("disabled_tools",)}
+
+            client = await get_mcp_client({server_name: client_config})
+            if client is None:
+                return []
+
+            raw_tools = cast(list[Any], await client.get_tools())
+
+            server_cc = to_camel_case(server_name)
+            for tool in raw_tools:
+                original_name = tool.name
+                tool_cc = to_camel_case(original_name)
+                unique_id = f"mcp__{server_cc}__{tool_cc}"
+
+                if tool.metadata is None:
+                    tool.metadata = {}
+                tool.metadata["id"] = unique_id
+                # 开启错误处理，防止工具调用抛出 ToolException 时击穿服务
+                tool.handle_tool_error = True
+                all_processed_tools.append(tool)
+
+            if cache:
+                async with _mcp_lock:
+                    stale_keys = [
+                        key for key in _mcp_tools_cache if key.startswith(f"{server_name}:") and key != cache_key
+                    ]
+                    for stale_key in stale_keys:
+                        _mcp_tools_cache.pop(stale_key, None)
+                    _mcp_tools_cache[cache_key] = all_processed_tools
+
+                global_config_disabled = server_config.get("disabled_tools") or []
+                enabled_count = len([t for t in all_processed_tools if t.name not in global_config_disabled])
+                _mcp_tools_stats[server_name] = {
+                    "total": len(all_processed_tools),
+                    "enabled": enabled_count,
+                    "disabled": len(all_processed_tools) - enabled_count,
+                }
+
+                logger.info(
+                    f"Refreshed MCP tools cache for '{server_name}' with key '{cache_key}': "
+                    f"{len(all_processed_tools)} tools loaded."
+                )
+
+        except Exception as e:
+            logger.error(
+                f"Failed to load tools from MCP server '{server_name}': {e}, traceback: {traceback.format_exc()}"
+            )
+            return []
+
+    # 3. Filtering (Apply to Return Value Only)
+    if disabled_tools:
+        filtered_tools = [t for t in all_processed_tools if t.name not in disabled_tools]
+        logger.debug(
+            f"Returning {len(filtered_tools)}/{len(all_processed_tools)} tools for '{server_name}' "
+            f"(filtered {len(disabled_tools)} by argument)"
+        )
+        return filtered_tools
+
+    return all_processed_tools
+
+
+async def get_tools_from_all_servers() -> list[Callable[..., Any]]:
+    """Get all tools from all configured MCP servers."""
+    server_configs = await _load_enabled_mcp_server_configs()
+    all_tools = []
+    for server_name in server_configs:
+        tools = await get_mcp_tools(server_name, additional_servers=server_configs)
+        all_tools.extend(tools)
+    return all_tools
+
+
+def clear_mcp_cache() -> None:
+    """Clear the MCP tools cache (useful for testing)."""
+    global _mcp_tools_cache, _mcp_tools_stats
+    _mcp_tools_cache = {}
+    _mcp_tools_stats = {}
+
+
+def clear_mcp_server_tools_cache(server_name: str) -> None:
+    """Clear the tools cache for a specific MCP server."""
+    global _mcp_tools_cache, _mcp_tools_stats
+    server_prefix = f"{server_name}:"
+    stale_keys = [key for key in _mcp_tools_cache if key.startswith(server_prefix)]
+    for stale_key in stale_keys:
+        _mcp_tools_cache.pop(stale_key, None)
+    _mcp_tools_stats.pop(server_name, None)
+    logger.info(f"Cleared tools cache for MCP server '{server_name}'")
+
+
+def get_mcp_tools_stats(server_name: str) -> dict[str, int] | None:
+    """Get tools statistics for a MCP server.
+
+    Returns:
+        dict with 'total', 'enabled', 'disabled' counts, or None if not available
+    """
+    return _mcp_tools_stats.get(server_name)
+
+
+# =============================================================================
+# === Unified Entry Points (Wrappers) ===
+# =============================================================================
+
+
+async def get_enabled_mcp_tools(server_name: str) -> list:
+    """Get MCP server tools (auto-filtering disabled_tools).
+
+    Unified entry point for Agents, automatically:
+    1. Gets the latest server config from database
+    2. Gets all tools
+    3. Filters out disabled_tools
+
+    Args:
+        server_name: Server name
+
+    Returns:
+        List of enabled tools
+    """
+    config = await get_enabled_mcp_server_config(server_name)
+    if config is None:
+        logger.warning(f"MCP server '{server_name}' not found in database or disabled")
+        return []
+
+    disabled_tools = config.get("disabled_tools") or []
+    return await get_mcp_tools(server_name, additional_servers={server_name: config}, disabled_tools=disabled_tools)
+
+
+async def get_all_mcp_tools(server_name: str) -> list:
+    """Get all tools of an MCP server (no filtering).
+
+    For management UI to display tool list, supports viewing all tools and their enabled status.
+    Does NOT update the global tools cache to avoid polluting agent's filtered view.
+
+    Args:
+        server_name: Server name
+
+    Returns:
+        List of all tools (unfiltered)
+    """
+    config = await get_enabled_mcp_server_config(server_name)
+    if config is None:
+        logger.warning(f"MCP server '{server_name}' not found in database or disabled")
+        return []
+
+    # Get all tools (no filtering, force refresh, no cache update)
+    return await get_mcp_tools(
+        server_name,
+        additional_servers={server_name: config},
+        disabled_tools=[],
+        cache=False,
+        force_refresh=True,
+    )

--- a/backend/package/yuxi/services/mcp/tool_registry_service.py
+++ b/backend/package/yuxi/services/mcp/tool_registry_service.py
@@ -21,8 +21,14 @@ from yuxi.utils import logger
 # === Global Cache & State ===
 # =============================================================================
 
-# Global Lock for MCP state
-_mcp_lock = asyncio.Lock()
+# Per-server locks to prevent concurrent duplicate initialization (Cache Stampede protection)
+_server_locks: dict[str, asyncio.Lock] = {}
+
+def _get_server_lock(server_name: str) -> asyncio.Lock:
+    """Get or create a lock for the given server name."""
+    if server_name not in _server_locks:
+        _server_locks[server_name] = asyncio.Lock()
+    return _server_locks[server_name]
 
 # 本地仅缓存工具对象。配置始终以数据库为准，每次按 server_name 现查。
 # cache key 使用 server_name:config_hash，当配置变化时会自然失效。
@@ -63,7 +69,7 @@ def to_camel_case(s: str) -> str:
 async def get_mcp_tools(
     server_name: str,
     additional_servers: dict[str, dict[str, Any]] | None = None,
-    disabled_tools: list[str] = None,
+    disabled_tools: list[str] | None = None,
     cache: bool = True,
     force_refresh: bool = False,
 ) -> list[Callable[..., Any]]:
@@ -98,36 +104,37 @@ async def get_mcp_tools(
 
     all_processed_tools: list[Callable[..., Any]] = []
 
-    async with _mcp_lock:
+    # 使用 per-server lock + double-check 模式，仅阻塞同一 server 的并发请求
+    server_lock = _get_server_lock(server_name)
+    async with server_lock:
         if not force_refresh and cache and cache_key in _mcp_tools_cache:
             all_processed_tools = _mcp_tools_cache[cache_key]
 
-    if not all_processed_tools:
-        try:
-            # disabled_tools 只影响返回值过滤，不参与 MCP client 建连参数。
-            client_config = {k: v for k, v in server_config.items() if k not in ("disabled_tools",)}
+        if not all_processed_tools:
+            try:
+                # disabled_tools 只影响返回值过滤，不参与 MCP client 建连参数。
+                client_config = {k: v for k, v in server_config.items() if k not in ("disabled_tools",)}
 
-            client = await get_mcp_client({server_name: client_config})
-            if client is None:
-                return []
+                client = await get_mcp_client({server_name: client_config})
+                if client is None:
+                    return []
 
-            raw_tools = cast(list[Any], await client.get_tools())
+                raw_tools = cast(list[Any], await client.get_tools())
 
-            server_cc = to_camel_case(server_name)
-            for tool in raw_tools:
-                original_name = tool.name
-                tool_cc = to_camel_case(original_name)
-                unique_id = f"mcp__{server_cc}__{tool_cc}"
+                server_cc = to_camel_case(server_name)
+                for tool in raw_tools:
+                    original_name = tool.name
+                    tool_cc = to_camel_case(original_name)
+                    unique_id = f"mcp__{server_cc}__{tool_cc}"
 
-                if tool.metadata is None:
-                    tool.metadata = {}
-                tool.metadata["id"] = unique_id
-                # 开启错误处理，防止工具调用抛出 ToolException 时击穿服务
-                tool.handle_tool_error = True
-                all_processed_tools.append(tool)
+                    if tool.metadata is None:
+                        tool.metadata = {}
+                    tool.metadata["id"] = unique_id
+                    # 开启错误处理，防止工具调用抛出 ToolException 时击穿服务
+                    tool.handle_tool_error = True
+                    all_processed_tools.append(tool)
 
-            if cache:
-                async with _mcp_lock:
+                if cache:
                     stale_keys = [
                         key for key in _mcp_tools_cache if key.startswith(f"{server_name}:") and key != cache_key
                     ]
@@ -135,24 +142,24 @@ async def get_mcp_tools(
                         _mcp_tools_cache.pop(stale_key, None)
                     _mcp_tools_cache[cache_key] = all_processed_tools
 
-                global_config_disabled = server_config.get("disabled_tools") or []
-                enabled_count = len([t for t in all_processed_tools if t.name not in global_config_disabled])
-                _mcp_tools_stats[server_name] = {
-                    "total": len(all_processed_tools),
-                    "enabled": enabled_count,
-                    "disabled": len(all_processed_tools) - enabled_count,
-                }
+                    global_config_disabled = server_config.get("disabled_tools") or []
+                    enabled_count = len([t for t in all_processed_tools if t.name not in global_config_disabled])
+                    _mcp_tools_stats[server_name] = {
+                        "total": len(all_processed_tools),
+                        "enabled": enabled_count,
+                        "disabled": len(all_processed_tools) - enabled_count,
+                    }
 
-                logger.info(
-                    f"Refreshed MCP tools cache for '{server_name}' with key '{cache_key}': "
-                    f"{len(all_processed_tools)} tools loaded."
+                    logger.info(
+                        f"Refreshed MCP tools cache for '{server_name}' with key '{cache_key}': "
+                        f"{len(all_processed_tools)} tools loaded."
+                    )
+
+            except Exception as e:
+                logger.error(
+                    f"Failed to load tools from MCP server '{server_name}': {e}, traceback: {traceback.format_exc()}"
                 )
-
-        except Exception as e:
-            logger.error(
-                f"Failed to load tools from MCP server '{server_name}': {e}, traceback: {traceback.format_exc()}"
-            )
-            return []
+                return []
 
     # 3. Filtering (Apply to Return Value Only)
     if disabled_tools:
@@ -178,9 +185,10 @@ async def get_tools_from_all_servers() -> list[Callable[..., Any]]:
 
 def clear_mcp_cache() -> None:
     """Clear the MCP tools cache (useful for testing)."""
-    global _mcp_tools_cache, _mcp_tools_stats
+    global _mcp_tools_cache, _mcp_tools_stats, _server_locks
     _mcp_tools_cache = {}
     _mcp_tools_stats = {}
+    _server_locks = {}
 
 
 def clear_mcp_server_tools_cache(server_name: str) -> None:
@@ -191,6 +199,7 @@ def clear_mcp_server_tools_cache(server_name: str) -> None:
     for stale_key in stale_keys:
         _mcp_tools_cache.pop(stale_key, None)
     _mcp_tools_stats.pop(server_name, None)
+    _server_locks.pop(server_name, None)
     logger.info(f"Cleared tools cache for MCP server '{server_name}'")
 
 

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import OperationalError
 from yuxi.repositories.agent_run_repository import TERMINAL_RUN_STATUSES, AgentRunRepository
 from yuxi.services.chat_service import stream_agent_chat
-from yuxi.services.mcp_service import ensure_builtin_mcp_servers_in_db
+from yuxi.services.mcp.server_service import ensure_builtin_mcp_servers_in_db
 from yuxi.services.run_queue_service import (
     append_run_stream_event,
     clear_cancel_signal,

--- a/backend/package/yuxi/services/skill_service.py
+++ b/backend/package/yuxi/services/skill_service.py
@@ -15,7 +15,7 @@ import yaml
 from sqlalchemy.ext.asyncio import AsyncSession
 from yuxi import config as sys_config
 from yuxi.repositories.skill_repository import SkillRepository
-from yuxi.services.mcp_service import get_enabled_mcp_server_names
+from yuxi.services.mcp.server_service import get_enabled_mcp_server_names
 from yuxi.storage.postgres.models_business import Skill
 from yuxi.utils.logging_config import logger
 

--- a/backend/server/routers/mcp_router.py
+++ b/backend/server/routers/mcp_router.py
@@ -4,17 +4,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from yuxi.services.mcp_service import (
+from yuxi.services.mcp.server_service import (
     create_mcp_server,
-    get_mcp_tools_stats,
     delete_mcp_server,
     get_all_mcp_servers,
-    get_all_mcp_tools,
     get_mcp_server,
     set_server_enabled,
     toggle_tool_enabled,
     update_mcp_server,
 )
+from yuxi.services.mcp.tool_registry_service import get_all_mcp_tools, get_mcp_tools_stats
 from yuxi.storage.postgres.models_business import User
 from yuxi.utils import logger
 from server.utils.auth_middleware import get_admin_user, get_db, get_required_user

--- a/backend/server/utils/lifespan.py
+++ b/backend/server/utils/lifespan.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
 from yuxi.services.task_service import tasker
-from yuxi.services.mcp_service import ensure_builtin_mcp_servers_in_db
+from yuxi.services.mcp.server_service import ensure_builtin_mcp_servers_in_db
 from yuxi.services.model_provider_service import ensure_builtin_model_providers_in_db
 from yuxi.services.subagent_service import init_builtin_subagents
 from yuxi.services.run_queue_service import close_queue_clients, get_redis_client

--- a/backend/test/unit/services/test_mcp_service.py
+++ b/backend/test/unit/services/test_mcp_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from yuxi.services import mcp_service
+from yuxi.services.mcp import tool_registry_service as mcp_service
 
 
 class _FakeClient:
@@ -135,4 +135,3 @@ async def test_get_mcp_tools_sets_handle_tool_error(monkeypatch):
     assert tools[0].handle_tool_error is True
 
     mcp_service.clear_mcp_cache()
-

--- a/backend/test/unit/services/test_mcp_service_split.py
+++ b/backend/test/unit/services/test_mcp_service_split.py
@@ -1,0 +1,15 @@
+from yuxi.services.mcp import server_service, tool_registry_service
+
+
+def test_mcp_service_split_exposes_server_and_tool_boundaries():
+    assert server_service.ensure_builtin_mcp_servers_in_db
+    assert server_service.create_mcp_server
+    assert server_service.update_mcp_server
+    assert server_service.delete_mcp_server
+    assert server_service.set_server_enabled
+    assert server_service.toggle_tool_enabled
+
+    assert tool_registry_service.get_mcp_tools
+    assert tool_registry_service.get_enabled_mcp_tools
+    assert tool_registry_service.get_all_mcp_tools
+    assert tool_registry_service.clear_mcp_cache


### PR DESCRIPTION
## 变更描述

> 🔥 务必注意，本项目不允许提交未经 “Human Review” 过的代码，不允许 Agent 未经人类审阅，直接提交 PR。不允许 Agent 直接提交回复。
>
> Code is Cheap, Show Me Your Thoughts!

将 MCP 服务层从单文件 `mcp_service.py`（626 行）拆分为有清晰职责边界的子包结构，对外 API 通过 `mcp/__init__.py` 统一 re-export，保持调用方无需逐个调整 import。

**拆分后模块职责：**
- `mcp/server_service.py` — MCP Server CRUD、内置配置同步、启停管理
- `mcp/tool_registry_service.py` — 工具发现/缓存、disabled_tools 过滤、统一 Agent 入口

**额外修复（PR review 反馈）：**
- Per-server lock 替代全局锁，避免 Cache Stampede
- Lock 范围覆盖完整 fetch-cache 周期，防止重复建连
- 修复 `disabled_tools` 类型注解（PEP 484）

**范围内/外说明：**
- 本次仅做服务层拆分，auth_config_json / MCPConnection / mcp_auth / internal proxy 等不在此范围（后续 PR 2-7 处理）

## 变更类型
- [ ] 新功能
- [ ] Bug 修复
- [ ] 文档更新
- [x] 其他（代码重构/模块拆分）

## 测试
- [ ] 已在 Docker 环境测试
- [ ] 相关功能正常工作

**相关日志或者截图**
- 15 files changed, 401 insertions, 297 deletions
- 新增 `test_mcp_service_split.py` 验证模块边界
- 更新 `test_mcp_service.py` 适配新路径
- GitHub 自动 CI 状态见 PR Checks 标签

## 说明
- 导入兼容性：`mcp/__init__.py` 集中 re-export 所有公开 API，已有 import 语句无需修改
- 循环依赖处理：`server_service._clear_mcp_server_tools_cache` 使用函数内延迟导入避免循环引用
- 缓存设计：`tool_registry_service` 使用 config_hash（SHA256）作为 cache key，配置变更自动触发缓存重建
- 本次分支基于 `release/0-6-3` 创建

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范