### PR TITLE
fix(mcp): 避免无关 MCP 阻塞 Agent 运行时

### DIFF
--- a/backend/package/yuxi/agents/buildin/chatbot/graph.py
+++ b/backend/package/yuxi/agents/buildin/chatbot/graph.py
@@ -13,7 +13,6 @@ from yuxi.agents.middlewares import (
 )
 from yuxi.agents.middlewares.knowledge_base_middleware import KnowledgeBaseMiddleware
 from yuxi.agents.middlewares.skills_middleware import SkillsMiddleware
-from yuxi.services.mcp.tool_registry_service import get_tools_from_all_servers
 from yuxi.services.subagent_service import get_subagents_from_names
 
 from .prompt import TODO_MID_PROMPT, build_prompt_with_context
@@ -21,8 +20,6 @@ from .prompt import TODO_MID_PROMPT, build_prompt_with_context
 
 async def _build_middlewares(context):
     """构建中间件列表"""
-    all_mcp_tools = await get_tools_from_all_servers()  # 因为异步加载，无法放在 RuntimeConfigMiddleware 的 __init__ 中
-
     # summary middleware
     # 主 Agent 上下文优化：90k tokens 触发压缩（128k context window 的 70%）
     summary_middleware = SummaryOffloadMiddleware(
@@ -50,7 +47,7 @@ async def _build_middlewares(context):
         FilesystemMiddleware(backend=create_agent_composite_backend),  # 文件系统后端
         save_attachments_to_fs,  # 附件注入提示词
         KnowledgeBaseMiddleware(),  # 知识库工具
-        RuntimeConfigMiddleware(extra_tools=all_mcp_tools),  # 运行时配置应用（模型/工具/MCP/提示词）
+        RuntimeConfigMiddleware(),  # 运行时配置应用（模型/工具/MCP/提示词）
         SkillsMiddleware(),  # Skills 中间件（提示词注入、依赖展开、动态激活）
         subagents_middleware,
         summary_middleware,

--- a/backend/package/yuxi/agents/buildin/deep_agent/graph.py
+++ b/backend/package/yuxi/agents/buildin/deep_agent/graph.py
@@ -17,7 +17,6 @@ from yuxi.agents.middlewares import (
 from yuxi.agents.middlewares.knowledge_base_middleware import KnowledgeBaseMiddleware
 from yuxi.agents.middlewares.skills_middleware import SkillsMiddleware
 from yuxi.agents.toolkits.buildin.tools import _create_tavily_search
-from yuxi.services.mcp.tool_registry_service import get_tools_from_all_servers
 from yuxi.services.subagent_service import get_subagents_from_names
 from yuxi.utils import logger
 
@@ -57,8 +56,6 @@ class DeepAgent(BaseAgent):
         model = load_chat_model(context.model)
         sub_model = load_chat_model(context.subagents_model)
         search_tools = await self.get_tools()
-        all_mcp_tools = await get_tools_from_all_servers()
-        # 合并搜索工具和 MCP 工具
 
         # 从数据库加载 subagent specs（工具名称已解析）
         user_subagents = await get_subagents_from_names(context.subagents)
@@ -97,7 +94,7 @@ class DeepAgent(BaseAgent):
             system_prompt="",
             middleware=[
                 FilesystemMiddleware(backend=create_agent_composite_backend),  # 文件系统后端
-                RuntimeConfigMiddleware(extra_tools=all_mcp_tools),
+                RuntimeConfigMiddleware(),
                 SkillsMiddleware(),  # Skills 中间件（提示词注入、依赖展开、动态激活）
                 save_attachments_to_fs,  # 附件注入提示词
                 TodoListMiddleware(system_prompt="任务结束前，应该检查维护的待办事项列表是否结束。"),

--- a/backend/package/yuxi/agents/middlewares/runtime_config_middleware.py
+++ b/backend/package/yuxi/agents/middlewares/runtime_config_middleware.py
@@ -100,7 +100,7 @@ class RuntimeConfigMiddleware(AgentMiddleware):
                 if t_bind.name in enabled_tools_by_name or t_bind.name not in managed_tool_names:
                     merged_tools.append(t_bind)
                     merged_tool_names.add(t_bind.name)
-            for tool in enabled_tools:
+            for tool in enabled_tools_by_name.values():
                 if tool.name not in merged_tool_names:
                     merged_tools.append(tool)
                     merged_tool_names.add(tool.name)

--- a/backend/package/yuxi/agents/middlewares/runtime_config_middleware.py
+++ b/backend/package/yuxi/agents/middlewares/runtime_config_middleware.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -89,14 +90,20 @@ class RuntimeConfigMiddleware(AgentMiddleware):
             # 获取上下文配置的工具
             enabled_tools = await self.get_tools_from_context(runtime_context)
             existing_tools = list(request.tools or [])
-            enabled_tool_names = {t.name for t in enabled_tools}
+            enabled_tools_by_name = {t.name: t for t in enabled_tools}
             managed_tool_names = {t.name for t in self.tools}
             merged_tools = []
+            merged_tool_names: set[str] = set()
             for t_bind in existing_tools:
                 # (1) 已启用的工具保留
                 # (2) 非本中间件管理的工具保留
-                if t_bind.name in enabled_tool_names or t_bind.name not in managed_tool_names:
+                if t_bind.name in enabled_tools_by_name or t_bind.name not in managed_tool_names:
                     merged_tools.append(t_bind)
+                    merged_tool_names.add(t_bind.name)
+            for tool in enabled_tools:
+                if tool.name not in merged_tool_names:
+                    merged_tools.append(tool)
+                    merged_tool_names.add(tool.name)
             overrides["tools"] = merged_tools
             logger.debug(f"RuntimeConfigMiddleware selected tools: {[t.name for t in merged_tools]}")
 
@@ -145,17 +152,20 @@ class RuntimeConfigMiddleware(AgentMiddleware):
             if isinstance(server_name, str):
                 all_mcp_names.append(server_name)
 
-        selected_mcp_servers: set[str] = set()
-        for server_name in all_mcp_names:
-            if server_name in selected_mcp_servers:
-                continue
-            selected_mcp_servers.add(server_name)
+        unique_mcp_names = list(dict.fromkeys(all_mcp_names))
+
+        async def load_mcp_tools(server_name: str) -> list:
             try:
                 mcp_tools = await get_enabled_mcp_tools(server_name)
                 if not mcp_tools:
                     logger.warning(f"RuntimeConfigMiddleware: mcp dependency unavailable, skip: {server_name}")
-                selected_tools.extend(mcp_tools)
+                return mcp_tools
             except Exception as e:
                 logger.warning(f"RuntimeConfigMiddleware: failed to load mcp dependency '{server_name}': {e}")
+                return []
+
+        results = await asyncio.gather(*[load_mcp_tools(name) for name in unique_mcp_names])
+        for mcp_tools in results:
+            selected_tools.extend(mcp_tools)
 
         return selected_tools

--- a/backend/package/yuxi/services/mcp/tool_registry_service.py
+++ b/backend/package/yuxi/services/mcp/tool_registry_service.py
@@ -24,11 +24,13 @@ from yuxi.utils import logger
 # Per-server locks to prevent concurrent duplicate initialization (Cache Stampede protection)
 _server_locks: dict[str, asyncio.Lock] = {}
 
+
 def _get_server_lock(server_name: str) -> asyncio.Lock:
     """Get or create a lock for the given server name."""
     if server_name not in _server_locks:
         _server_locks[server_name] = asyncio.Lock()
     return _server_locks[server_name]
+
 
 # 本地仅缓存工具对象。配置始终以数据库为准，每次按 server_name 现查。
 # cache key 使用 server_name:config_hash，当配置变化时会自然失效。
@@ -36,6 +38,8 @@ _mcp_tools_cache: dict[str, list[Callable[..., Any]]] = {}
 
 # MCP tools statistics (for reporting enabled/disabled counts)
 _mcp_tools_stats: dict[str, dict[str, int]] = {}
+
+MCP_TOOLS_DISCOVERY_TIMEOUT_SECONDS = 10
 
 # =============================================================================
 # === Core Logic (Moved from agents/common/mcp.py) ===
@@ -237,7 +241,16 @@ async def get_enabled_mcp_tools(server_name: str) -> list:
         return []
 
     disabled_tools = config.get("disabled_tools") or []
-    return await get_mcp_tools(server_name, additional_servers={server_name: config}, disabled_tools=disabled_tools)
+    try:
+        return await asyncio.wait_for(
+            get_mcp_tools(server_name, additional_servers={server_name: config}, disabled_tools=disabled_tools),
+            timeout=MCP_TOOLS_DISCOVERY_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        logger.warning(
+            f"MCP server '{server_name}' tool discovery timed out after {MCP_TOOLS_DISCOVERY_TIMEOUT_SECONDS}s, skip"
+        )
+        return []
 
 
 async def get_all_mcp_tools(server_name: str) -> list:

--- a/backend/test/unit/agents/test_runtime_mcp_loading.py
+++ b/backend/test/unit/agents/test_runtime_mcp_loading.py
@@ -51,6 +51,33 @@ async def test_runtime_config_middleware_adds_context_mcp_tools(monkeypatch):
     assert [tool.name for tool in captured["tools"]] == ["base_tool", "mcp_tool"]
 
 
+async def test_runtime_config_middleware_uses_last_enabled_tool_when_names_conflict(monkeypatch):
+    first_mcp_tool = SimpleNamespace(name="mcp_tool", source="alpha")
+    last_mcp_tool = SimpleNamespace(name="mcp_tool", source="beta")
+
+    async def fake_get_enabled_mcp_tools(server_name: str):
+        return {"alpha": [first_mcp_tool], "beta": [last_mcp_tool]}[server_name]
+
+    monkeypatch.setattr(runtime_module, "get_all_tool_instances", lambda: [])
+    monkeypatch.setattr(runtime_module, "get_enabled_mcp_tools", fake_get_enabled_mcp_tools)
+
+    middleware = RuntimeConfigMiddleware(
+        enable_model_override=False,
+        enable_system_prompt_override=False,
+    )
+    context = SimpleNamespace(tools=[], mcps=["alpha", "beta"])
+    request = _FakeRequest(context=context, tools=[])
+    captured = {}
+
+    async def handler(updated_request):
+        captured["tools"] = updated_request.tools
+        return SimpleNamespace()
+
+    await middleware.awrap_model_call(request, handler)
+
+    assert captured["tools"] == [last_mcp_tool]
+
+
 async def test_chatbot_graph_build_does_not_scan_all_mcp_servers(monkeypatch):
     from yuxi.agents.buildin.chatbot import graph as chatbot_graph
 

--- a/backend/test/unit/agents/test_runtime_mcp_loading.py
+++ b/backend/test/unit/agents/test_runtime_mcp_loading.py
@@ -1,0 +1,137 @@
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from yuxi.agents.middlewares import runtime_config_middleware as runtime_module
+from yuxi.agents.middlewares.runtime_config_middleware import RuntimeConfigMiddleware
+
+
+class _FakeRequest:
+    def __init__(self, *, context, tools):
+        self.runtime = SimpleNamespace(context=context)
+        self.tools = tools
+        self.system_message = None
+
+    def override(self, **overrides):
+        return SimpleNamespace(
+            runtime=self.runtime,
+            tools=overrides.get("tools", self.tools),
+            system_message=overrides.get("system_message", self.system_message),
+        )
+
+
+async def test_runtime_config_middleware_adds_context_mcp_tools(monkeypatch):
+    base_tool = SimpleNamespace(name="base_tool")
+    mcp_tool = SimpleNamespace(name="mcp_tool")
+    loaded_servers: list[str] = []
+
+    async def fake_get_enabled_mcp_tools(server_name: str):
+        loaded_servers.append(server_name)
+        return [mcp_tool]
+
+    monkeypatch.setattr(runtime_module, "get_all_tool_instances", lambda: [base_tool])
+    monkeypatch.setattr(runtime_module, "get_enabled_mcp_tools", fake_get_enabled_mcp_tools)
+
+    middleware = RuntimeConfigMiddleware(
+        enable_model_override=False,
+        enable_system_prompt_override=False,
+    )
+    context = SimpleNamespace(tools=["base_tool"], mcps=["alpha"])
+    request = _FakeRequest(context=context, tools=[base_tool])
+    captured = {}
+
+    async def handler(updated_request):
+        captured["tools"] = updated_request.tools
+        return SimpleNamespace()
+
+    await middleware.awrap_model_call(request, handler)
+
+    assert loaded_servers == ["alpha"]
+    assert [tool.name for tool in captured["tools"]] == ["base_tool", "mcp_tool"]
+
+
+async def test_chatbot_graph_build_does_not_scan_all_mcp_servers(monkeypatch):
+    from yuxi.agents.buildin.chatbot import graph as chatbot_graph
+
+    async def fail_if_global_mcp_scan_runs():
+        raise AssertionError("graph build must not scan all enabled MCP servers")
+
+    def named(name):
+        return SimpleNamespace(name=name)
+
+    async def fake_get_subagents_from_names(names):
+        return []
+
+    runtime_kwargs = []
+
+    monkeypatch.setattr(chatbot_graph, "get_tools_from_all_servers", fail_if_global_mcp_scan_runs, raising=False)
+    monkeypatch.setattr(chatbot_graph, "load_chat_model", lambda *args, **kwargs: named("model"))
+    monkeypatch.setattr(chatbot_graph, "SummaryOffloadMiddleware", lambda **kwargs: named("summary"))
+    monkeypatch.setattr(chatbot_graph, "get_subagents_from_names", fake_get_subagents_from_names)
+    monkeypatch.setattr(chatbot_graph, "SubAgentMiddleware", lambda **kwargs: named("subagents"))
+    monkeypatch.setattr(chatbot_graph, "FilesystemMiddleware", lambda **kwargs: named("filesystem"))
+    monkeypatch.setattr(chatbot_graph, "PatchToolCallsMiddleware", lambda: named("patch"))
+    monkeypatch.setattr(chatbot_graph, "KnowledgeBaseMiddleware", lambda: named("knowledge"))
+    monkeypatch.setattr(chatbot_graph, "SkillsMiddleware", lambda: named("skills"))
+    monkeypatch.setattr(chatbot_graph, "TodoListMiddleware", lambda **kwargs: named("todo"))
+    monkeypatch.setattr(chatbot_graph, "ModelRetryMiddleware", lambda: named("retry"))
+    monkeypatch.setattr(
+        chatbot_graph,
+        "RuntimeConfigMiddleware",
+        lambda **kwargs: runtime_kwargs.append(kwargs) or named("runtime"),
+    )
+
+    context = SimpleNamespace(model="model", subagents_model="sub-model", subagents=[], summary_threshold=100)
+
+    await chatbot_graph._build_middlewares(context)
+
+    assert runtime_kwargs == [{}]
+
+
+async def test_deep_agent_graph_build_does_not_scan_all_mcp_servers(monkeypatch):
+    from yuxi.agents.buildin.deep_agent import graph as deep_graph
+
+    async def fail_if_global_mcp_scan_runs():
+        raise AssertionError("graph build must not scan all enabled MCP servers")
+
+    def named(name):
+        return SimpleNamespace(name=name)
+
+    async def fake_get_tools(self):
+        return []
+
+    async def fake_get_checkpointer(self):
+        return None
+
+    async def fake_get_subagents_from_names(names):
+        return []
+
+    runtime_kwargs = []
+
+    monkeypatch.setattr(deep_graph, "get_tools_from_all_servers", fail_if_global_mcp_scan_runs, raising=False)
+    monkeypatch.setattr(deep_graph, "load_chat_model", lambda *args, **kwargs: named("model"))
+    monkeypatch.setattr(deep_graph.DeepAgent, "get_tools", fake_get_tools)
+    monkeypatch.setattr(deep_graph.DeepAgent, "_get_checkpointer", fake_get_checkpointer)
+    monkeypatch.setattr(deep_graph, "get_subagents_from_names", fake_get_subagents_from_names)
+    monkeypatch.setattr(deep_graph, "SummaryOffloadMiddleware", lambda **kwargs: named("summary"))
+    monkeypatch.setattr(deep_graph, "SubAgentMiddleware", lambda **kwargs: named("subagents"))
+    monkeypatch.setattr(deep_graph, "FilesystemMiddleware", lambda **kwargs: named("filesystem"))
+    monkeypatch.setattr(deep_graph, "PatchToolCallsMiddleware", lambda: named("patch"))
+    monkeypatch.setattr(deep_graph, "KnowledgeBaseMiddleware", lambda: named("knowledge"))
+    monkeypatch.setattr(deep_graph, "SkillsMiddleware", lambda: named("skills"))
+    monkeypatch.setattr(deep_graph, "TodoListMiddleware", lambda **kwargs: named("todo"))
+    monkeypatch.setattr(deep_graph, "ToolCallLimitMiddleware", lambda **kwargs: named("limit"))
+    monkeypatch.setattr(
+        deep_graph,
+        "RuntimeConfigMiddleware",
+        lambda **kwargs: runtime_kwargs.append(kwargs) or named("runtime"),
+    )
+    monkeypatch.setattr(deep_graph, "create_agent", lambda **kwargs: kwargs)
+
+    context = SimpleNamespace(model="model", subagents_model="sub-model", subagents=[])
+    agent = deep_graph.DeepAgent()
+
+    await agent.get_graph(context=context)
+
+    assert runtime_kwargs == [{}]

--- a/backend/test/unit/services/test_mcp_service.py
+++ b/backend/test/unit/services/test_mcp_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 from yuxi.services.mcp import tool_registry_service as mcp_service
@@ -41,12 +42,31 @@ async def test_get_enabled_mcp_tools_loads_latest_config_from_db(monkeypatch):
     assert captured == [
         {
             "server_name": "demo",
-            "additional_servers": {
-                "demo": {"transport": "stdio", "command": "demo", "disabled_tools": ["tool_b"]}
-            },
+            "additional_servers": {"demo": {"transport": "stdio", "command": "demo", "disabled_tools": ["tool_b"]}},
             "disabled_tools": ["tool_b"],
         }
     ]
+
+
+async def test_get_enabled_mcp_tools_times_out_slow_runtime_discovery(monkeypatch):
+    async def fake_get_enabled_mcp_server_config(server_name: str, db=None):
+        del db
+        assert server_name == "slow"
+        return {"transport": "streamable_http", "url": "http://slow.example/mcp", "disabled_tools": []}
+
+    async def fake_get_mcp_tools(server_name: str, additional_servers=None, disabled_tools=None, **kwargs):
+        del additional_servers, disabled_tools, kwargs
+        assert server_name == "slow"
+        await asyncio.sleep(0.05)
+        return ["late-tool"]
+
+    monkeypatch.setattr(mcp_service, "MCP_TOOLS_DISCOVERY_TIMEOUT_SECONDS", 0.01, raising=False)
+    monkeypatch.setattr(mcp_service, "get_enabled_mcp_server_config", fake_get_enabled_mcp_server_config)
+    monkeypatch.setattr(mcp_service, "get_mcp_tools", fake_get_mcp_tools)
+
+    tools = await mcp_service.get_enabled_mcp_tools("slow")
+
+    assert tools == []
 
 
 async def test_get_mcp_tools_rebuilds_cache_when_config_hash_changes(monkeypatch):


### PR DESCRIPTION
## 变更描述

> 🔥 务必注意，本项目不允许提交未经 “Human Review” 过的代码，不允许 Agent 未经人类审阅，直接提交 PR。不允许 Agent 直接提交回复。
>
> Code is Cheap, Show Me Your Thoughts!

简要描述这个 PR 做了什么

- 测试过程中发现，配置错误的mcp导致问答时卡死，需要等15分钟才能结束会话。或者会话结束后，state接口要等很久才有响应。故分析后得出需要先修复该问题，再继续后续pr

## 变更描述
这个 PR 单独修复 SUP-19 的 runtime hotfix：无 MCP 配置的 Agent 不应在 graph 构建或 `/state` 路径扫描全局 enabled MCP；显式配置了坏 MCP 时，也不应长期阻塞 worker 问答。

为什么需要这个 PR：

- 旧逻辑在 ChatbotAgent / DeepAgent 构建 graph 时调用 `get_tools_from_all_servers()`，会扫描数据库里所有 enabled MCP。
- 即使 Agent 没有配置 MCP，一个坏 MCP 也可能拖慢 `/api/chat/thread/{id}/state` 或问答运行链路。
- 配置了 MCP 时，坏 MCP 的 tool discovery 也需要故障隔离，不能把 worker 卡住。
- 这是纯 runtime bugfix，不包含 SUP-13 / PR2 的 MCP Auth、schema、CRUD、加密、权限等新能力。

本次改动：

- ChatbotAgent / DeepAgent graph 构建阶段不再加载全局 MCP。
- RuntimeConfigMiddleware 改为只按 `context.mcps` 加载显式配置的 MCP tools，并合并进本次 request tools。
- `get_enabled_mcp_tools()` 增加 10 秒 discovery 上限，慢挂起 MCP 超时后返回空工具；快速失败 MCP 会立即跳过。
- 多个 MCP 并发加载，单个 MCP 失败不影响其他 MCP 或后续问答。
- 增加回归测试覆盖 graph 构建不扫描全局 MCP、runtime MCP tool 合并、慢 MCP discovery 超时。


## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

- `OPENAI_API_KEY=test uv run --group test pytest test/unit/agents/test_runtime_mcp_loading.py test/unit/agents/test_deep_agent_context.py test/unit/services/test_mcp_service.py -q`
  - 结果：10 passed，3 warnings
- `OPENAI_API_KEY=test uv run ruff check package/yuxi/agents/buildin/chatbot/graph.py package/yuxi/agents/buildin/deep_agent/graph.py package/yuxi/agents/middlewares/runtime_config_middleware.py package/yuxi/services/mcp/tool_registry_service.py test/unit/agents/test_runtime_mcp_loading.py test/unit/services/test_mcp_service.py`
  - 结果：All checks passed
- `OPENAI_API_KEY=test uv run ruff format --check package/yuxi/agents/buildin/chatbot/graph.py package/yuxi/agents/buildin/deep_agent/graph.py package/yuxi/agents/middlewares/runtime_config_middleware.py package/yuxi/services/mcp/tool_registry_service.py test/unit/agents/test_runtime_mcp_loading.py test/unit/services/test_mcp_service.py`
  - 结果：6 files already formatted
- `docker compose exec api uv run --group test pytest test/unit/agents/test_runtime_mcp_loading.py test/unit/agents/test_deep_agent_context.py test/unit/services/test_mcp_service.py -q`
  - 结果：10 passed，3 warnings

## 说明
（可选）有什么需要特别说明的吗？

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范
